### PR TITLE
Check for and avoid division by zero error in _cross_coef function

### DIFF
--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -235,7 +235,11 @@ def _cross_coef(A, B, sample_weight):
     ssA = np.average(A_mA**2, axis=0, weights=sample_weight)
 
     # Finally get corr coeff
-    return A_mA.T.dot(np.diag(sample_weight)).dot(B_mB)/sample_weight.sum() / ssA[:, None]
+    numerator = A_mA.T.dot(np.diag(sample_weight)).dot(B_mB)/sample_weight.sum()
+    if np.sum(ssA[:, None]) > 0:
+        return numerator / ssA[:, None]
+    else:
+        return numerator
 
 
 def _cross_coef_resampled(A, B, sample_weight):


### PR DESCRIPTION
I was encountering a lot of division by zero errors when running memento.ht_1d_moments() on my data. There may be some underlying issue with my data or a more elegant way to clean things up here, but adding these couple lines of code to _cross_coef() allows me to run without errors.