### PR TITLE
Add adaptive bootstrap sampling for differential mean expression + faster unique-count generation 

### DIFF
--- a/benchmarks/benchmark_bootstrap.py
+++ b/benchmarks/benchmark_bootstrap.py
@@ -1,0 +1,46 @@
+"""Small, reproducible benchmark for bootstrap state compression."""
+
+from time import perf_counter
+
+import numpy as np
+from scipy import sparse
+
+from memento import bootstrap
+
+
+def legacy_random_projection(expression, size_factor):
+    """The pre-refactor compression path, retained only for comparison."""
+
+    generator = np.random.default_rng(42)
+    code = expression.dot(generator.random(expression.shape[1]))
+    code += generator.random() * size_factor
+    _, index, counts = np.unique(code, return_index=True, return_counts=True)
+    return expression[index], size_factor[index], counts
+
+
+def best_time(function, repeats=10):
+    timings = []
+    for _ in range(repeats):
+        start = perf_counter()
+        function()
+        timings.append(perf_counter() - start)
+    return min(timings)
+
+
+def main():
+    rng = np.random.default_rng(42)
+    num_cells = 500_000
+    expression = sparse.csc_matrix(rng.negative_binomial(2, 0.7, (num_cells, 2)))
+    size_factor = rng.choice(np.linspace(500, 5000, 30), size=num_cells)
+
+    legacy_seconds = best_time(lambda: legacy_random_projection(expression, size_factor))
+    exact_seconds = best_time(lambda: bootstrap._unique_expr(expression, size_factor))
+
+    print(f"cells={num_cells:,} genes={expression.shape[1]}")
+    print(f"legacy_random_projection_seconds={legacy_seconds:.6f}")
+    print(f"exact_mixed_radix_seconds={exact_seconds:.6f}")
+    print(f"speedup={legacy_seconds / exact_seconds:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/memento/__init__.py
+++ b/memento/__init__.py
@@ -14,3 +14,23 @@ from .main import (
     get_corr_matrix, 
     get_groups)
 from .wrappers import run_eqtl, binary_test_1d, binary_test_2d
+
+__all__ = [
+    'setup_memento',
+    'create_groups',
+    'compute_1d_moments',
+    'compute_2d_moments',
+    'ht_mean',
+    'ht_1d_moments',
+    'ht_2d_moments',
+    'get_1d_moments',
+    'get_2d_moments',
+    'get_mean_ht_result',
+    'get_1d_ht_result',
+    'get_2d_ht_result',
+    'get_corr_matrix',
+    'get_groups',
+    'run_eqtl',
+    'binary_test_1d',
+    'binary_test_2d',
+]

--- a/memento/bootstrap.py
+++ b/memento/bootstrap.py
@@ -4,13 +4,13 @@
     This file contains functions for fast bootstraping.
 """
 
-import scipy.stats as stats
 import numpy as np
 import pandas as pd
-import string
 import time
-import statsmodels.api as sm
-import warnings
+
+
+_MAX_DENSE_STATE_BINS = 1_000_000
+_DEFAULT_BOOTSTRAP_BATCH_BYTES = 64 * 1024**2
 
 
 def numpy_fill(arr):
@@ -39,36 +39,92 @@ def _convert_params(mu, alpha):
 
 def _unique_expr(expr, size_factor):
     """
-        Precompute the size factor to separate it from the bootstrap.
-        This function also serves to find and count unique values.
-        
-        :expr: is a sparse matrix, either one or two columns
-        
-        FIXIT: we don't need to sorting functionality of np.unique. try to do this faster.
+    Compress cells with identical expression and size factor states.
+
+    ``expr`` is a sparse count matrix with one or two columns. Memento bins
+    size factors before bootstrapping, so the number of distinct states is
+    generally small even for very large cell populations.
+
+    The previous implementation projected each state onto a random float and
+    then called ``np.unique``. Besides requiring an O(n log n) sort, that could
+    merge distinct states after a projection collision and changed NumPy's
+    global random state. Integer count states are now encoded exactly with a
+    mixed-radix key and counted in O(n) time when the key space is compact.
     """
-    
-    # Remove outliers
-#     with warnings.catch_warnings():
-#         warnings.simplefilter("ignore")
-#         params = sm.NegativeBinomial(expr.todense().A1, np.ones((expr.shape[0], 1))).fit(disp=0).params
-#     mu_hat = np.exp(params[0])
-#     alpha_hat = params[1]
-#     probs = stats.nbinom.pmf(expr.todense().A1, *_convert_params(mu_hat, alpha_hat))
-#     inliers = probs > 0.1/expr.shape[0]
-    
-#     expr = expr#[inliers]
-#     size_factor = size_factor#[inliers]
-    
-    code = expr.dot(np.random.random(expr.shape[1]))
-    approx_sf = size_factor
-        
-    code += np.random.random()*approx_sf
-    
-    _, index, count = np.unique(code, return_index=True, return_counts=True)
-    
-    expr_to_return = expr[index].toarray()
-    
-    return 1/approx_sf[index].reshape(-1, 1), 1/approx_sf[index].reshape(-1, 1)**2, expr_to_return, count
+
+    size_factor = np.asarray(size_factor)
+    if size_factor.ndim != 1 or size_factor.shape[0] != expr.shape[0]:
+        raise ValueError("size_factor must have one finite, positive value per cell")
+    if np.any(~np.isfinite(size_factor)) or np.any(size_factor <= 0):
+        raise ValueError("size_factor must have one finite, positive value per cell")
+
+    dense_expr = np.asarray(expr.toarray())
+    rounded_expr = np.rint(dense_expr)
+    integer_counts = (
+        np.all(np.isfinite(dense_expr))
+        and np.all(dense_expr >= 0)
+        and np.array_equal(dense_expr, rounded_expr)
+        and (dense_expr.size == 0 or dense_expr.max() <= np.iinfo(np.int64).max)
+    )
+
+    if integer_counts:
+        count_expr = rounded_expr.astype(np.int64, copy=False)
+        sf_code, sf_values = pd.factorize(size_factor, sort=False)
+        radices = [int(count_expr[:, idx].max()) + 1 for idx in range(count_expr.shape[1])]
+
+        state_space = len(sf_values)
+        for radix in radices:
+            state_space *= radix
+
+        if state_space <= np.iinfo(np.int64).max:
+            code = sf_code.astype(np.int64, copy=True)
+            for idx, radix in enumerate(radices):
+                code *= radix
+                code += count_expr[:, idx]
+
+            if state_space <= _MAX_DENSE_STATE_BINS:
+                all_counts = np.bincount(code)
+                unique_code = np.flatnonzero(all_counts)
+                counts = all_counts[unique_code]
+            else:
+                unique_code, counts = np.unique(code, return_counts=True)
+
+            decoded = unique_code.copy()
+            unique_expr = np.empty((unique_code.size, count_expr.shape[1]), dtype=count_expr.dtype)
+            for idx in range(count_expr.shape[1] - 1, -1, -1):
+                unique_expr[:, idx] = decoded % radices[idx]
+                decoded //= radices[idx]
+            unique_sf = np.asarray(sf_values)[decoded]
+
+            inv_sf = (1 / unique_sf).reshape(-1, 1)
+            return inv_sf, inv_sf**2, unique_expr, counts
+
+    # Counts should normally take the fast path. Keep an exact fallback for
+    # custom estimators that supply non-integer expression values.
+    fields = [("size_factor", size_factor.dtype)]
+    fields.extend((f"expr_{idx}", dense_expr.dtype) for idx in range(dense_expr.shape[1]))
+    states = np.empty(expr.shape[0], dtype=fields)
+    states["size_factor"] = size_factor
+    for idx in range(dense_expr.shape[1]):
+        states[f"expr_{idx}"] = dense_expr[:, idx]
+
+    _, index, counts = np.unique(states, return_index=True, return_counts=True)
+    unique_sf = size_factor[index]
+    inv_sf = (1 / unique_sf).reshape(-1, 1)
+    return inv_sf, inv_sf**2, dense_expr[index], counts
+
+
+def _get_batch_size(num_categories, num_boot, batch_size):
+    """Choose a bootstrap batch size that bounds the multinomial count array."""
+
+    if batch_size is not None:
+        if batch_size < 1:
+            raise ValueError("batch_size must be a positive integer")
+        return min(int(batch_size), num_boot)
+
+    bytes_per_bootstrap = max(1, num_categories) * np.dtype(np.int64).itemsize
+    memory_limited_size = max(1, _DEFAULT_BOOTSTRAP_BATCH_BYTES // bytes_per_bootstrap)
+    return min(num_boot, memory_limited_size)
 
 
 def _bootstrap_1d(
@@ -78,6 +134,7 @@ def _bootstrap_1d(
     _estimator_1d,
     num_boot=1000,
     return_times=False,
+    batch_size=None,
     **kwargs):
     """
         Perform the bootstrap and CI calculation for mean and variance.
@@ -100,14 +157,22 @@ def _bootstrap_1d(
     n_obs = data.shape[0]
         
     gen = np.random.Generator(np.random.PCG64(5))
-    gene_rvs = gen.multinomial(data.shape[0], counts/counts.sum(), size=num_boot).T
-        
-    # Estimate mean and variance
-    mean, var = _estimator_1d(
-        data=(expr, gene_rvs),
-        n_obs=n_obs,
-        q=q,
-        size_factor=(inv_sf, inv_sf_sq))
+    batch_size = _get_batch_size(counts.size, num_boot, batch_size)
+    mean = np.empty(num_boot)
+    var = np.empty(num_boot)
+
+    for start in range(0, num_boot, batch_size):
+        stop = min(start + batch_size, num_boot)
+        gene_rvs = gen.multinomial(
+            data.shape[0], counts / counts.sum(), size=stop - start).T
+
+        batch_mean, batch_var = _estimator_1d(
+            data=(expr, gene_rvs),
+            n_obs=n_obs,
+            q=q,
+            size_factor=(inv_sf, inv_sf_sq))
+        mean[start:stop] = batch_mean
+        var[start:stop] = batch_var
     boot_time = time.time()
     
     if return_times:
@@ -123,7 +188,8 @@ def _bootstrap_2d(
     _estimator_1d,
     _estimator_cov,
     num_boot=1000,
-    precomputed=None):
+    precomputed=None,
+    batch_size=None):
     """
         Perform the bootstrap and CI calculation for covariance and correlation.
     """
@@ -131,28 +197,32 @@ def _bootstrap_2d(
 
     inv_sf, inv_sf_sq, expr, counts = _unique_expr(data, size_factor) if precomputed is None else precomputed
     
-    # Generate the bootstrap samples
-    gen = np.random.Generator(np.random.PCG64(5))
-#     gene_rvs = gen.poisson(counts, size=(num_boot, counts.shape[0])).T
-    gene_rvs = gen.multinomial(data.shape[0], counts/counts.sum(), size=num_boot).T
     n_obs = Nc
-    
-    # Estimate the covariance and variance
-    cov = _estimator_cov(
-        data=(expr[:, 0].reshape(-1, 1), expr[:, 1].reshape(-1, 1), gene_rvs), 
-        n_obs=n_obs, 
-        q=q,
-        size_factor=(inv_sf, inv_sf_sq))
-    _, var_1 = _estimator_1d(
-        data=(expr[:, 0].reshape(-1, 1), gene_rvs),
-        n_obs=n_obs,
-        q=q,
-        size_factor=(inv_sf, inv_sf_sq))
-    _, var_2 = _estimator_1d(
-        data=(expr[:, 1].reshape(-1, 1), gene_rvs),
-        n_obs=n_obs,
-        q=q,
-        size_factor=(inv_sf, inv_sf_sq))
-                
+    gen = np.random.Generator(np.random.PCG64(5))
+    batch_size = _get_batch_size(counts.size, num_boot, batch_size)
+    cov = np.empty(num_boot)
+    var_1 = np.empty(num_boot)
+    var_2 = np.empty(num_boot)
+
+    for start in range(0, num_boot, batch_size):
+        stop = min(start + batch_size, num_boot)
+        gene_rvs = gen.multinomial(
+            data.shape[0], counts / counts.sum(), size=stop - start).T
+
+        cov[start:stop] = _estimator_cov(
+            data=(expr[:, 0:1], expr[:, 1:2], gene_rvs),
+            n_obs=n_obs,
+            q=q,
+            size_factor=(inv_sf, inv_sf_sq))
+        _, var_1[start:stop] = _estimator_1d(
+            data=(expr[:, 0:1], gene_rvs),
+            n_obs=n_obs,
+            q=q,
+            size_factor=(inv_sf, inv_sf_sq))
+        _, var_2[start:stop] = _estimator_1d(
+            data=(expr[:, 1:2], gene_rvs),
+            n_obs=n_obs,
+            q=q,
+            size_factor=(inv_sf, inv_sf_sq))
+
     return cov, var_1, var_2
-        

--- a/memento/bootstrap.py
+++ b/memento/bootstrap.py
@@ -135,6 +135,7 @@ def _bootstrap_1d(
     num_boot=1000,
     return_times=False,
     batch_size=None,
+    rng=None,
     **kwargs):
     """
         Perform the bootstrap and CI calculation for mean and variance.
@@ -156,7 +157,9 @@ def _bootstrap_1d(
     
     n_obs = data.shape[0]
         
-    gen = np.random.Generator(np.random.PCG64(5))
+    # Keep the historical stream for direct internal calls. Public hypothesis
+    # tests provide a per-gene generator that advances across biological groups.
+    gen = np.random.Generator(np.random.PCG64(5)) if rng is None else rng
     batch_size = _get_batch_size(counts.size, num_boot, batch_size)
     mean = np.empty(num_boot)
     var = np.empty(num_boot)
@@ -189,7 +192,8 @@ def _bootstrap_2d(
     _estimator_cov,
     num_boot=1000,
     precomputed=None,
-    batch_size=None):
+    batch_size=None,
+    rng=None):
     """
         Perform the bootstrap and CI calculation for covariance and correlation.
     """
@@ -198,7 +202,7 @@ def _bootstrap_2d(
     inv_sf, inv_sf_sq, expr, counts = _unique_expr(data, size_factor) if precomputed is None else precomputed
     
     n_obs = Nc
-    gen = np.random.Generator(np.random.PCG64(5))
+    gen = np.random.Generator(np.random.PCG64(5)) if rng is None else rng
     batch_size = _get_batch_size(counts.size, num_boot, batch_size)
     cov = np.empty(num_boot)
     var_1 = np.empty(num_boot)

--- a/memento/estimator.py
+++ b/memento/estimator.py
@@ -10,44 +10,45 @@
 """
 
 import scipy.sparse as sparse
-import scipy.stats as stats
-import scipy.interpolate as inter
 import numpy as np
-import pickle as pkl
 
 
 def _get_estimator_1d(estimator_type):
-    
-    if estimator_type == 'hyper_absolute':
-        return _hyper_1d_absolute
-    elif estimator_type == 'hyper_relative':
-        return _hyper_1d_relative
-    elif estimator_type == 'poi_absolute':
-        return _poi_1d_absolute
-    elif estimator_type == 'poi_relative':
-        return _poi_1d_relative
-    elif estimator_type == 'mean_only':
-        return _mean_only_1p
-    elif estimator_type == 'good_mean_only':
-        return _good_mean_only
-    elif estimator_type == 'pseudobulk':
-        return _pseudobulk
-    else: # Custom 1D estimator
-        return estimator_type[0]
+
+    estimators = {
+        'hyper_relative': _hyper_1d_relative,
+        'poi_relative': _poisson_1d_relative,
+        'mean_only': _mean_only_1p,
+        'good_mean_only': _good_mean_only,
+        'pseudobulk': _pseudobulk,
+    }
+    if isinstance(estimator_type, str):
+        try:
+            return estimators[estimator_type]
+        except KeyError as exc:
+            supported = ', '.join(sorted(estimators))
+            raise ValueError(
+                f"Unknown estimator_type {estimator_type!r}; expected one of: {supported}"
+            ) from exc
+    return estimator_type[0]
 
     
 def _get_estimator_cov(estimator_type):
-    
-    if estimator_type == 'hyper_absolute':
-        return _hyper_cov_absolute
-    elif estimator_type == 'hyper_relative':
-        return _hyper_cov_relative
-    elif estimator_type == 'poi_absolute':
-        return _poi_cov_absolute
-    elif estimator_type == 'poi_relative':
-        return _poi_cov_relative
-    else: # Custom covariance estimator
-        return estimator_type[1]
+
+    estimators = {
+        'hyper_relative': _hyper_cov_relative,
+        'poi_relative': _poisson_cov_relative,
+    }
+    if isinstance(estimator_type, str):
+        try:
+            return estimators[estimator_type]
+        except KeyError as exc:
+            supported = ', '.join(sorted(estimators))
+            raise ValueError(
+                f"Unknown covariance estimator_type {estimator_type!r}; "
+                f"expected one of: {supported}"
+            ) from exc
+    return estimator_type[1]
     
     
 def bincount2d_sparse(sparse_arr, bins=None):
@@ -110,13 +111,6 @@ def _fit_mv_regressor(mean, var):
     
     poly = np.polyfit(m, v, 2)
     return poly
-    f = np.poly1d(z)
-    
-#     spline = inter.UnivariateSpline(m[np.argsort(m)], v[np.argsort(m)])
-#     return spline
-
-#     slope, inter, _, _, _ = stats.linregress(m, v)
-#     return slope, inter
 
 
 def _residual_variance(mean, var, mv_fit):
@@ -136,7 +130,7 @@ def _poisson_1d_relative(data, n_obs, size_factor=None):
         
         If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
     """
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         size_factor = size_factor if size_factor is not None else (1, 1)
         mm_M1 = (data[0]*data[1]*size_factor[0]).sum(axis=0)/n_obs
         mm_M2 = (data[0]**2*data[1]*size_factor[1] - data[0]*data[1]*size_factor[1]).sum(axis=0)/n_obs
@@ -159,7 +153,7 @@ def _poisson_cov_relative(data, n_obs, size_factor, idx1, idx2):
         If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
     """
     
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         obs_M1 = (data[0]*data[2]*size_factor[0]).sum(axis=0)/n_obs
         obs_M2 = (data[1]*data[2]*size_factor[0]).sum(axis=0)/n_obs
         obs_MX = (data[0]*data[1]*data[2]*size_factor[1]).sum(axis=0)/n_obs
@@ -187,7 +181,7 @@ def _hyper_1d_relative(data, n_obs, q, size_factor=None):
         
         If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
     """
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         size_factor = size_factor if size_factor is not None else (1, 1)
         mm_M1 = (data[0]*data[1]*size_factor[0]).sum(axis=0)/n_obs
         mm_M2 = (data[0]**2*data[1]*size_factor[1] - (1-q)*data[0]*data[1]*size_factor[1]).sum(axis=0)/n_obs
@@ -211,10 +205,10 @@ def _pseudobulk(data: sparse.csc_matrix, n_obs, q, size_factor: np.array):
         If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
     """
                 
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         size_factor = size_factor if size_factor is not None else (1, 1)
         unique_expr, bootstrap_freq = data[0], data[1]
-        inverse_size_factor, inverse_size_factor_sq = size_factor[0], size_factor[1]
+        inverse_size_factor = size_factor[0]
         
         m = ((unique_expr * bootstrap_freq).sum(axis=0)+1) / ((bootstrap_freq/inverse_size_factor).sum(axis=0))
     else:
@@ -227,7 +221,7 @@ def _mean_only_1p(data, n_obs, q, size_factor=None):
     """
         Estimate the mean with pseudocount with no variance (returns 1)
     """
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         size_factor = size_factor if size_factor is not None else (1, 1)
         mm_M1 = (data[0]*data[1]*size_factor[0]).sum(axis=0)/n_obs
     else:
@@ -245,16 +239,12 @@ def _good_mean_only(data, n_obs, q, size_factor=None, alpha=0, max_to_replace=13
         Hypergeometric mean estimator based on Good's estimator.
     """
 
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         return
     else:
 
         arr = data
         n_genes = data.shape[1]
-        pb = (arr.sum(axis=0).A1+1)
-        total_umi = pb.sum()
-        denom = np.array([total_umi - pb[sparse.find(arr[i])[1]].sum() for i in range(n_obs)]).mean()
-
         freqs = bincount2d_sparse(arr)
         expected_freqs = freqs.mean(axis=0).A1
         initial_values = np.tile(np.arange(max_to_replace)[:,np.newaxis], (1,n_genes))
@@ -267,7 +257,6 @@ def _good_mean_only(data, n_obs, q, size_factor=None, alpha=0, max_to_replace=13
 
         corrected_counts = sparse.diags(1/size_factor) @ corrected_counts # normalize for size_factor
         nonzero_sum = corrected_counts.sum(axis=0).A1
-        num_zeros_per_column = arr.shape[0] - arr.getnnz(axis=0)
         zero_sum = np.array([(final_values[0, idx]/size_factor[~np.in1d(range(size_factor.shape[0]), sparse.find(arr[:, idx])[0])]).sum() for idx in range(n_genes)])
         m = (nonzero_sum + zero_sum)/arr.shape[0]
         
@@ -281,7 +270,7 @@ def _hyper_cov_relative(data, n_obs, size_factor, q, idx1=None, idx2=None):
         If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
     """
     
-    if type(data) == tuple:
+    if isinstance(data, tuple):
         obs_M1 = (data[0]*data[2]*size_factor[0]).sum(axis=0)/n_obs
         obs_M2 = (data[1]*data[2]*size_factor[0]).sum(axis=0)/n_obs
         obs_MX = (data[0]*data[1]*data[2]*size_factor[1]).sum(axis=0)/n_obs
@@ -345,7 +334,7 @@ def _corr_from_cov(cov, var_1, var_2, boot=False):
         Convert the estimation of the covariance to the estimation of correlation.
     """
     
-    if type(cov) != np.ndarray:
+    if not isinstance(cov, np.ndarray):
         return cov/np.sqrt(var_1*var_2)
         
     corr = np.full(cov.shape, 5.0)

--- a/memento/estimators/mean.py
+++ b/memento/estimators/mean.py
@@ -1,103 +1,20 @@
+"""Mean estimator compatibility exports.
+
+The active implementations are kept in :mod:`memento.estimator`. Re-exporting
+them here preserves the intended submodule API without maintaining a second,
+divergent copy of the same numerical code.
 """
-	mean.py
-	
-	Contains the estimators and hypothesis testing framework for the mean.
-	
-"""
 
-import scipy.sparse as sparse
-import scipy.stats as stats
-import scipy.interpolate as inter
-import numpy as np
-import pickle as pkl
+from memento.estimator import (
+    _good_mean_only,
+    _hyper_1d_relative,
+    _mean_only_1p,
+    _pseudobulk,
+)
 
-
-def _pseudobulk(data: sparse.csc_matrix, size_factor: np.array)
-    """ 
-        Computes the pseudobulk mean with pseudocount adjustment. 
-        :X: is a sparse matrix in CSC format. 
-    """"
-                
-                
-    mean = (data.sum(axis=0).A1+1)/(size_factor.sum()+1)
-    
-    return m, np.ones(m.shape)*10
-    
-def _hyper_1d_relative(data, n_obs, q, size_factor=None):
-    """
-        Estimate the variance using the hypergeometric noise process.
-        
-        If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
-    """
-    if type(data) == tuple:
-        size_factor = size_factor if size_factor is not None else (1, 1)
-        mm_M1 = (data[0]*data[1]*size_factor[0]).sum(axis=0)/n_obs
-        mm_M2 = (data[0]**2*data[1]*size_factor[1] - (1-q)*data[0]*data[1]*size_factor[1]).sum(axis=0)/n_obs
-    else:
-        
-        row_weight = (1/size_factor).reshape([1, -1])
-        row_weight_sq = (1/size_factor**2).reshape([1, -1])
-        mm_M1 = sparse.csc_matrix.dot(row_weight, data).ravel()/n_obs
-        mm_M2 = sparse.csc_matrix.dot(row_weight_sq, data.power(2)).ravel()/n_obs - (1-q)*sparse.csc_matrix.dot(row_weight_sq, data).ravel()/n_obs
-    
-    mm_mean = mm_M1
-    mm_var = (mm_M2 - mm_M1**2)
-
-    return [mm_mean, mm_var]
-
-
-def _mean_only_1p(data, n_obs, q, size_factor=None):
-    """
-        Estimate the variance using the Poisson noise process.
-        
-        If :data: is a tuple, :cell_size: should be a tuple of (inv_sf, inv_sf_sq). Otherwise, it should be an array of length data.shape[0].
-    """
-    if type(data) == tuple:
-        size_factor = size_factor if size_factor is not None else (1, 1)
-        mm_M1 = (data[0]*data[1]*size_factor[0]).sum(axis=0)/n_obs
-    else:
-        
-        row_weight = (1/size_factor).reshape([1, -1])
-        mm_M1 = sparse.csc_matrix.dot(row_weight, data).ravel()/n_obs
-    
-    mm_mean = mm_M1
-
-    return [mm_mean+1, np.ones(mm_mean.shape)*10]
-
-
-def _good_mean_only(data, n_obs, q, size_factor=None, alpha=0, max_to_replace=13):
-    """
-        Hypergeometric mean estimator based on Good's estimator.
-    """
-
-    if type(data) == tuple:
-        return
-    else:
-
-        arr = data
-        n_genes = data.shape[1]
-        pb = (arr.sum(axis=0).A1+1)
-        total_umi = pb.sum()
-        denom = np.array([total_umi - pb[sparse.find(arr[i])[1]].sum() for i in range(n_obs)]).mean()
-
-        freqs = bincount2d_sparse(arr)
-        expected_freqs = freqs.mean(axis=0).A1
-        initial_values = np.tile(np.arange(max_to_replace)[:,np.newaxis], (1,n_genes))
-        final_values = (initial_values + 1) * expected_freqs[initial_values+1] / expected_freqs[initial_values]
-        final_values[0] = 0#(0+1) * expected_freqs[1] * (alpha*(pb/denom) + ((1-alpha)/expected_freqs[0]))
-
-        corrected_counts = sparse.csr_matrix(arr, dtype=float)
-        for val in range(1,max_to_replace):
-            corrected_counts.data[corrected_counts.data == val] = final_values[val, 0]
-
-        corrected_counts = sparse.diags(1/size_factor) @ corrected_counts # normalize for size_factor
-        nonzero_sum = corrected_counts.sum(axis=0).A1
-        num_zeros_per_column = arr.shape[0] - arr.getnnz(axis=0)
-        zero_sum = np.array([(final_values[0, idx]/size_factor[~np.in1d(range(size_factor.shape[0]), sparse.find(arr[:, idx])[0])]).sum() for idx in range(n_genes)])
-        m = (nonzero_sum + zero_sum)/arr.shape[0]
-        
-        return [m, np.ones(m.shape)*10]
-
-
-
-
+__all__ = [
+    "_good_mean_only",
+    "_hyper_1d_relative",
+    "_mean_only_1p",
+    "_pseudobulk",
+]

--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -24,7 +24,15 @@ def _robust_log(val):
     return np.log(val)
 
 
-def _fill(val):
+def _choice(rng, values, size):
+    return (
+        np.random.choice(values, size)
+        if rng is None
+        else rng.choice(values, size)
+    )
+
+
+def _fill(val, rng=None):
     
     condition = np.less_equal(val, 0., where=~np.isnan(val)) | np.isnan(val)
     num_invalid = condition.sum()
@@ -32,18 +40,18 @@ def _fill(val):
     if num_invalid == val.shape[0]:
         return None
     
-    val[condition] = np.random.choice(val[~condition], num_invalid)
+    val[condition] = _choice(rng, val[~condition], num_invalid)
     
     return val
 
-def _fill_corr(val):
+def _fill_corr(val, rng=None):
     
     condition = np.less_equal(val, -1.0, where=~np.isnan(val)) | np.greater_equal(val, 1.0, where=~np.isnan(val)) | np.isnan(val)
         
     if val[~condition].shape[0] == 0:
         return None
     
-    val[condition] = np.random.choice(val[~condition], condition.sum())
+    val[condition] = _choice(rng, val[~condition], condition.sum())
     
     return val
 
@@ -161,6 +169,7 @@ def _get_bootstrap_samples(
     mv_fit, # list of tuples
     q, # list of numbers
     _estimator_1d,
+    rng=None,
     **kwargs):
     """
         Returns a tuple of ( <indices of good samples>, <bootstrap sample means>, <
@@ -191,14 +200,15 @@ def _get_bootstrap_samples(
             num_boot=num_boot,
             q=q[group_idx],
             _estimator_1d=_estimator_1d,
+            rng=rng,
             **kwargs)
 
         # Compute the residual variance
         res_var = estimator._residual_variance(mean, var, mv_fit[group_idx])
 
         # Minimize invalid values
-        filled_mean = _fill(mean)#_push_nan(mean)#[:num_boot]
-        filled_var = _fill(res_var)#_push_nan(res_var)#[:num_boot]
+        filled_mean = _fill(mean, rng=rng)#_push_nan(mean)#[:num_boot]
+        filled_var = _fill(res_var, rng=rng)#_push_nan(res_var)#[:num_boot]
 
         # Make sure its a valid replicate
         if filled_mean is None or filled_var is None:
@@ -330,12 +340,13 @@ def _ht_1d(
     mv_fit, # list of tuples
     q, # list of numbers
     _estimator_1d,
+    random_state=None,
     **kwargs):
     """
         Performs hypothesis testing of the mean and variance using bootstrap.
     """
     
-    # Get the bootstrap sample statistics for each replicate
+    rng = None if random_state is None else np.random.default_rng(random_state)
     good_idxs, boot_mean, boot_var = _get_bootstrap_samples(
         true_mean,
         true_res_var,
@@ -347,7 +358,8 @@ def _ht_1d(
         num_boot,
         mv_fit,
         q,
-        _estimator_1d)
+        _estimator_1d,
+        rng=rng)
     
     vals = _regress_1d(
             covariate=covariate[good_idxs, :],
@@ -355,6 +367,7 @@ def _ht_1d(
             boot_mean=np.log(boot_mean[good_idxs, :]), 
             boot_var=np.log(boot_var[good_idxs, :]),
             Nc_list=Nc_list[good_idxs],
+            rng=rng,
             **kwargs)
     return vals
 
@@ -371,6 +384,10 @@ def _mean_summary_statistics(
     mv_fit, # list of tuples
     q, # list of numbers
     _estimator_1d,
+    random_state=None,
+    target_se_rse=None,
+    min_boot=250,
+    bootstrap_resolution=50,
     **kwargs):
     """
         Performs hypothesis testing of the mean.
@@ -380,7 +397,23 @@ def _mean_summary_statistics(
         - `wls`: WLS regression based on bootstrap-estimated standard errors
         - `quasi-GLM`: Applies a global variance estimation and correction
     """
-    # Get the bootstrap sample statistics for each replicate
+    rng = None if random_state is None else np.random.default_rng(random_state)
+    if target_se_rse is not None:
+        return _adaptive_mean_summary_statistics(
+            true_mean=true_mean,
+            true_res_var=true_res_var,
+            cells=cells,
+            approx_sf=approx_sf,
+            num_boot=num_boot,
+            q=q,
+            _estimator_1d=_estimator_1d,
+            rng=rng,
+            target_se_rse=target_se_rse,
+            min_boot=min_boot,
+            bootstrap_resolution=bootstrap_resolution,
+            **kwargs,
+        )
+
     good_idxs, boot_mean, boot_var = _get_bootstrap_samples(
         true_mean,
         true_res_var,
@@ -392,7 +425,8 @@ def _mean_summary_statistics(
         num_boot,
         mv_fit,
         q,
-        _estimator_1d)
+        _estimator_1d,
+        rng=rng)
     
     sem = np.nanstd(boot_mean, axis=1)
     pos_boot_mean = boot_mean.copy()
@@ -402,6 +436,130 @@ def _mean_summary_statistics(
     
     return np.nanmean(boot_mean, axis=1), sem, selm, sel1pm
     return np.array(true_mean), sem, selm, sel1pm 
+
+
+def _plan_bootstrap_draws(
+    data,
+    size_factor,
+    target_se_rse,
+    min_boot,
+    max_boot,
+    resolution,
+):
+    """Plan pseudobulk draws from the ratio estimator's influence kurtosis."""
+
+    expression = np.asarray(data.toarray()).ravel().astype(float, copy=False)
+    size_factor = np.asarray(size_factor, dtype=float)
+    denominator = size_factor.sum()
+    if denominator <= 0 or not np.isfinite(denominator):
+        return max_boot, np.inf
+
+    ratio = (expression.sum() + 1) / denominator
+    influence = expression - ratio * size_factor
+    centered = influence - influence.mean()
+    variance = np.mean(centered**2)
+    if not np.isfinite(variance) or variance <= 0:
+        return min_boot, 0.0
+
+    influence_kurtosis = np.mean(centered**4) / variance**2
+    statistic_kurtosis = 3 + (influence_kurtosis - 3) / expression.size
+    statistic_kurtosis = max(float(statistic_kurtosis), 1.0)
+    required = int(
+        np.ceil((statistic_kurtosis - 1) / (4 * target_se_rse**2))
+    )
+    planned = max(min_boot, required)
+    planned = int(np.ceil(planned / resolution) * resolution)
+    planned = min(planned, max_boot)
+    predicted_rse = (
+        np.sqrt(max(statistic_kurtosis - 1, 0)) / (2 * np.sqrt(planned))
+        if planned > 0
+        else np.inf
+    )
+    return planned, predicted_rse
+
+
+def _adaptive_mean_summary_statistics(
+    true_mean,
+    true_res_var,
+    cells,
+    approx_sf,
+    num_boot,
+    q,
+    _estimator_1d,
+    rng,
+    target_se_rse,
+    min_boot,
+    bootstrap_resolution,
+    **kwargs,
+):
+    """Preallocate ordinary bootstrap draws to target group SE precision."""
+
+    if not np.isfinite(target_se_rse) or target_se_rse <= 0:
+        raise ValueError("target_se_rse must be a positive finite number")
+    if min_boot < 4 or min_boot > num_boot:
+        raise ValueError("min_boot must be between 4 and num_boot")
+    if bootstrap_resolution < 1:
+        raise ValueError("bootstrap_resolution must be a positive integer")
+    if getattr(_estimator_1d, "__name__", None) != "_pseudobulk":
+        raise ValueError(
+            "target_se_rse currently supports only estimator_type='pseudobulk'"
+        )
+
+    num_groups = len(true_mean)
+    summary_mean = np.full(num_groups, np.nan)
+    summary_sem = np.full(num_groups, np.nan)
+    summary_selm = np.full(num_groups, np.nan)
+    summary_sel1pm = np.full(num_groups, np.nan)
+    draws_used = np.zeros(num_groups, dtype=int)
+    predicted_rse = np.full(num_groups, np.nan)
+
+    for group_idx in range(num_groups):
+        if (
+            np.isnan(true_mean[group_idx])
+            or np.isnan(true_res_var[group_idx])
+            or true_mean[group_idx] == 0
+            or true_res_var[group_idx] < 0
+        ):
+            continue
+
+        planned_draws, group_predicted_rse = _plan_bootstrap_draws(
+            data=cells[group_idx],
+            size_factor=approx_sf[group_idx],
+            target_se_rse=target_se_rse,
+            min_boot=min_boot,
+            max_boot=num_boot,
+            resolution=bootstrap_resolution,
+        )
+        mean, _ = bootstrap._bootstrap_1d(
+            data=cells[group_idx],
+            size_factor=approx_sf[group_idx],
+            num_boot=planned_draws,
+            q=q[group_idx],
+            _estimator_1d=_estimator_1d,
+            rng=rng,
+            **kwargs,
+        )
+        draws = _fill(mean, rng=rng)
+        if draws is None:
+            continue
+        values = np.concatenate(([true_mean[group_idx]], draws))
+        positive = values.copy()
+        positive[positive < 0] = np.nan
+        summary_mean[group_idx] = np.nanmean(values)
+        summary_sem[group_idx] = np.nanstd(values)
+        summary_selm[group_idx] = np.nanstd(np.log(positive))
+        summary_sel1pm[group_idx] = np.nanstd(np.log(positive + 1))
+        draws_used[group_idx] = planned_draws
+        predicted_rse[group_idx] = group_predicted_rse
+
+    return (
+        summary_mean,
+        summary_sem,
+        summary_selm,
+        summary_sel1pm,
+        draws_used,
+        predicted_rse,
+    )
 
 
 def _cross_coef(A, B, sample_weight):
@@ -436,7 +594,16 @@ def _cross_coef_resampled(A, B, sample_weight):
     return beta
 
 
-def _regress_1d(covariate, treatment, boot_mean, boot_var, Nc_list, resample_rep=False,**kwargs):
+def _regress_1d(
+    covariate,
+    treatment,
+    boot_mean,
+    boot_var,
+    Nc_list,
+    resample_rep=False,
+    rng=None,
+    **kwargs,
+):
     """
         Performs hypothesis testing for a single gene for many bootstrap iterations.
         
@@ -469,9 +636,13 @@ def _regress_1d(covariate, treatment, boot_mean, boot_var, Nc_list, resample_rep
 
         if resample_rep:            
 
-            replicate_assignment = np.random.choice(num_rep, size=(num_rep, num_boot))
+            replicate_assignment = _choice(
+                rng, num_rep, size=(num_rep, num_boot)
+            )
             replicate_assignment[:, 0] = np.arange(num_rep)
-            b_iter_assignment = np.random.choice(num_boot, (num_rep, num_boot))+1
+            b_iter_assignment = _choice(
+                rng, num_boot, size=(num_rep, num_boot)
+            ) + 1
             b_iter_assignment[:, 0] = 0
 
             boot_mean_resampled = boot_mean_tilde[(replicate_assignment, b_iter_assignment)]
@@ -510,9 +681,11 @@ def _ht_2d(
     q,
     _estimator_1d,
     _estimator_cov,
+    random_state=None,
     **kwargs):
     
         
+    rng = None if random_state is None else np.random.default_rng(random_state)
     good_idxs = np.zeros(treatment.shape[0], dtype=bool)
     
     # the bootstrap arrays
@@ -535,12 +708,13 @@ def _ht_2d(
             q=q[group_idx],
             _estimator_1d=_estimator_1d,
             _estimator_cov=_estimator_cov,
-            precomputed=None)
+            precomputed=None,
+            rng=rng)
 
         corr = estimator._corr_from_cov(cov, var_1, var_2, boot=True)
 
         # This replicate is good
-        vals = _fill_corr(corr)
+        vals = _fill_corr(corr, rng=rng)
 
         # Skip if all NaNs
         if vals is None:
@@ -560,12 +734,21 @@ def _ht_2d(
             treatment=treatment[good_idxs, :],
             boot_corr=boot_corr[good_idxs, :],
             Nc_list=Nc_list[good_idxs],
+            rng=rng,
             **kwargs)
     
     return vals
 
 
-def _regress_2d(covariate, treatment, boot_corr, Nc_list, resample_rep=False, **kwargs):
+def _regress_2d(
+    covariate,
+    treatment,
+    boot_corr,
+    Nc_list,
+    resample_rep=False,
+    rng=None,
+    **kwargs,
+):
     """
         Performs hypothesis testing for a single pair of genes for many bootstrap iterations.
     """    
@@ -593,9 +776,13 @@ def _regress_2d(covariate, treatment, boot_corr, Nc_list, resample_rep=False, **
 
         if resample_rep:
 
-            replicate_assignment = np.random.choice(num_rep, size=(num_rep, num_boot))
+            replicate_assignment = _choice(
+                rng, num_rep, size=(num_rep, num_boot)
+            )
             replicate_assignment[:, 0] = np.arange(num_rep)
-            b_iter_assignment = np.random.choice(num_boot, (num_rep, num_boot))+1
+            b_iter_assignment = _choice(
+                rng, num_boot, size=(num_rep, num_boot)
+            ) + 1
             b_iter_assignment[:, 0] = 0
 
             boot_corr_resampled = boot_corr_tilde[(replicate_assignment, b_iter_assignment)]

--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -7,7 +7,6 @@
 import numpy as np
 import pandas as pd
 import scipy.stats as stats
-import scipy.sparse as sparse
 from sklearn.linear_model import LinearRegression
 import warnings
 from functools import partial
@@ -142,7 +141,7 @@ def _compute_asl(perm_diff, approx='norm'):
 
                 return (extreme_count+1) / (null.shape[0]+1)
 
-            except: # catch any numerical errors
+            except Exception: # catch any numerical errors
 
                 # Failed to fit genpareto, return the upper bound
                 return (extreme_count+1) / (null.shape[0]+1)
@@ -173,8 +172,6 @@ def _get_bootstrap_samples(
     boot_mean = np.zeros((treatment.shape[0], num_boot+1))*np.nan
     boot_var = np.zeros((treatment.shape[0], num_boot+1))*np.nan
     
-    boot_means = []
-
     for group_idx in range(len(true_mean)):
 
         # Skip if any of the 1d moments are NaNs
@@ -213,21 +210,28 @@ def _get_bootstrap_samples(
 #         # This replicate is good
         good_idxs[group_idx] = True
         
-    # Validity flag
-    valid = (good_idxs.sum() != 0)
-    
     return good_idxs, boot_mean, boot_var
     
 
-def _ht_mean_quasiML(results, treatment, covariate, total_umi, umi_depth, group_names, gene_names, return_fits=False):
+def _ht_mean_quasiML(
+    results,
+    treatment,
+    covariate,
+    total_umi,
+    umi_depth,
+    group_names,
+    gene_names,
+    return_fits=False,
+    num_cpus=1,
+    treatment_for_gene=None,
+    covariate_for_gene=None,
+):
     """
     Differential mean expression using quasiML method, most suited for multi-sample data 
     where there are few samples but significant inter-sample variability. 
     
     :results: is a list of aggregate statistics for the mean from bootstrapping. 
     """
-    
-    results_df = pd.DataFrame(results)
     
     mean_df = pd.DataFrame([a[0] for a in results], columns=group_names, index=gene_names).T
     sem_df = pd.DataFrame([a[1] for a in results], columns=group_names, index=gene_names).T
@@ -240,17 +244,20 @@ def _ht_mean_quasiML(results, treatment, covariate, total_umi, umi_depth, group_
     regressions = []
     for idx, gene in enumerate(expr.columns):
 
-        # if treatment_for_gene is not None:
-        #     if gene in treatment_for_gene: # Get treatments for this gene
-        #         treatment_list = treatment_for_gene[gene]
-        #     else: # Pass this gene
-        #         continue
-        # else: # Default, get all pairwise treatment-gene tests
-        treatment_list = treatment.columns
+        treatment_list = (
+            treatment.columns
+            if treatment_for_gene is None
+            else treatment_for_gene[gene]
+        )
+        gene_covariate = (
+            covariate
+            if covariate_for_gene is None
+            else covariate[covariate_for_gene[gene]]
+        )
 
         for t in treatment_list:
 
-            design_matrix = pd.concat([covariate, treatment[[t]]], axis=1)
+            design_matrix = pd.concat([gene_covariate, treatment[[t]]], axis=1)
 
             regressions.append(
                 partial(
@@ -260,7 +267,7 @@ def _ht_mean_quasiML(results, treatment, covariate, total_umi, umi_depth, group_
                     offset=np.log(total_umi.flatten()), 
                     gene=gene, 
                     t=t))
-    regression_fits = Parallel(n_jobs=14, verbose=1)(delayed(func)() for func in regressions)
+    regression_fits = Parallel(n_jobs=num_cpus, verbose=1)(delayed(func)() for func in regressions)
     
     # For debugging purposes
     if return_fits:
@@ -276,7 +283,6 @@ def _ht_mean_quasiML(results, treatment, covariate, total_umi, umi_depth, group_
 
     for idx in range(all_pred.shape[1]):
 
-        e = all_endog[:, idx]
         m = all_pred[:, idx]
         v = all_resid_variance[:, idx]
         slope, inter, _, _, _ = stats.linregress(np.log10(m),np.log10(v))
@@ -290,25 +296,22 @@ def _ht_mean_quasiML(results, treatment, covariate, total_umi, umi_depth, group_
     logging.info(f'mv slope: {mv_slope}')
     
     result = []
-    error_counter = 0
     for fit in regression_fits:
         coef = fit['model'].params[fit['t']]
         X = fit['design'].values
         pred = fit['pred']
-        endog = fit['endog']
-
         intra_var = sampling_variance[fit['gene']].values
         inter_var = pred**mv_slope # from M-V relationship above
         total_var = intra_var + inter_var
 
         try:
             W = (pred**2) / total_var
-            var = np.diag(np.linalg.pinv(X.T@np.diag(W)@X))[-1]
+            weighted_information = X.T @ (W[:, np.newaxis] * X)
+            var = np.diag(np.linalg.pinv(weighted_information))[-1]
             se = np.sqrt(var)
             pv = 2*stats.norm.sf(np.abs(coef/se))
-        except:
+        except Exception:
             se, pv = np.nan, np.nan
-            error_counter+=1
 
         result.append((fit['gene'], fit['t'], coef, se, pv))
 
@@ -411,7 +414,8 @@ def _cross_coef(A, B, sample_weight):
     ssA = np.average(A_mA**2, axis=0, weights=sample_weight)
 
     # Finally get corr coeff
-    return A_mA.T.dot(np.diag(sample_weight)).dot(B_mB)/sample_weight.sum() / ssA[:, None]
+    weighted_B = sample_weight[:, np.newaxis] * B_mB
+    return A_mA.T.dot(weighted_B) / sample_weight.sum() / ssA[:, None]
 
 
 def _cross_coef_resampled(A, B, sample_weight):

--- a/memento/main.py
+++ b/memento/main.py
@@ -55,6 +55,18 @@ def _get_test_genes_and_indices(adata, treatment_for_gene):
     return test_genes, data_indices
 
 
+def _spawn_task_random_states(random_state, n_tasks):
+    """Create reproducible per-task seeds independent of worker scheduling."""
+
+    if random_state is None:
+        return [None] * n_tasks
+    seed_sequence = np.random.SeedSequence(random_state)
+    return [
+        int(child.generate_state(1, dtype=np.uint64)[0])
+        for child in seed_sequence.spawn(n_tasks)
+    ]
+
+
 def setup_memento(
     adata,
     q_column,
@@ -393,6 +405,7 @@ def ht_1d_moments(
     num_boot=10000, 
     verbose=1,
     num_cpus=1,
+    random_state=5,
     **kwargs):
     """
         Performs hypothesis testing for 1D moments.
@@ -425,7 +438,12 @@ def ht_1d_moments(
     mean_coef, mean_se, mean_asl, var_coef, var_se, var_asl = [np.zeros(num_tests)*np.nan for i in range(6)]
     
     ht_funcs = []
-    for test_gene, data_idx in zip(test_genes, test_gene_indices):
+    task_random_states = _spawn_task_random_states(
+        random_state, len(test_genes)
+    )
+    for test_gene, data_idx, task_random_state in zip(
+        test_genes, test_gene_indices, task_random_states
+    ):
 
         ht_funcs.append(
             partial(
@@ -441,6 +459,7 @@ def ht_1d_moments(
                 mv_fit=[adata.uns['memento']['mv_regressor'][group] for group in adata.uns['memento']['groups']],
                 q=[adata.uns['memento']['group_q'][group] for group in adata.uns['memento']['groups']],
                 _estimator_1d=estimator._get_estimator_1d(adata.uns['memento']['estimator_type']),
+                random_state=task_random_state,
                 **kwargs))
 
     results = Parallel(n_jobs=num_cpus, verbose=verbose)(delayed(func)() for func in ht_funcs)
@@ -466,6 +485,7 @@ def ht_1d_moments(
         'var_coef': var_coef,
         'var_se': var_se,
         'var_asl': var_asl,
+        'random_state': random_state,
     })
 
     if not inplace:
@@ -482,9 +502,18 @@ def ht_mean(
     verbose=1,
     num_cpus=1,
     return_stats=False,
+    random_state=5,
+    target_se_rse=None,
+    min_boot=250,
+    bootstrap_resolution=50,
     **kwargs):
     """
-        Performs hypothesis testing for 1D moments.
+        Performs differential-mean testing.
+
+        Set ``target_se_rse`` to preallocate a gene- and group-specific
+        bootstrap count from the pseudobulk estimator's influence kurtosis.
+        The draw count is chosen before resampling, so it does not introduce
+        optional-stopping bias. ``num_boot`` remains the hard upper bound.
     """
     
     if not inplace:
@@ -516,7 +545,12 @@ def ht_mean(
     mean_coef, mean_se, mean_asl = [np.zeros(num_tests)*np.nan for i in range(3)]
     
     get_stats_funcs = []
-    for test_gene, data_idx in zip(test_genes, test_gene_indices):
+    task_random_states = _spawn_task_random_states(
+        random_state, len(test_genes)
+    )
+    for test_gene, data_idx, task_random_state in zip(
+        test_genes, test_gene_indices, task_random_states
+    ):
         
         get_stats_funcs.append(
             partial(
@@ -532,12 +566,48 @@ def ht_mean(
                 mv_fit=[adata.uns['memento']['mv_regressor'][group] for group in adata.uns['memento']['groups']],
                 q=[adata.uns['memento']['group_q'][group] for group in adata.uns['memento']['groups']],
                 _estimator_1d=estimator._get_estimator_1d(adata.uns['memento']['estimator_type']),
+                random_state=task_random_state,
+                target_se_rse=target_se_rse,
+                min_boot=min_boot,
+                bootstrap_resolution=bootstrap_resolution,
                 **kwargs))
 
     logging.info('Computing statistics for differential mean')
 
     agg_statistics = Parallel(n_jobs=num_cpus, verbose=verbose)(delayed(func)() for func in get_stats_funcs)
     
+    bootstrap_diagnostics = None
+    if target_se_rse is not None:
+        draws_used = np.vstack([result[4] for result in agg_statistics])
+        predicted_rse = np.vstack([result[5] for result in agg_statistics])
+        agg_statistics = [result[:4] for result in agg_statistics]
+        used = draws_used[draws_used > 0]
+        finite_rse = predicted_rse[np.isfinite(predicted_rse)]
+        bootstrap_diagnostics = {
+            'mode': 'adaptive',
+            'target_se_rse': target_se_rse,
+            'min_boot': min_boot,
+            'max_boot': num_boot,
+            'bootstrap_resolution': bootstrap_resolution,
+            'draw_quantiles': (
+                np.quantile(used, [0, 0.5, 0.9, 0.99, 1]).tolist()
+                if used.size
+                else []
+            ),
+            'mean_draws': float(used.mean()) if used.size else np.nan,
+            'fraction_at_max': (
+                float(np.mean(used == num_boot)) if used.size else np.nan
+            ),
+            'draw_reduction_factor': (
+                float(num_boot / used.mean()) if used.size else np.nan
+            ),
+            'predicted_se_rse_quantiles': (
+                np.quantile(finite_rse, [0, 0.5, 0.9, 0.99, 1]).tolist()
+                if finite_rse.size
+                else []
+            ),
+        }
+
     if return_stats:
         return agg_statistics
 
@@ -568,6 +638,8 @@ def ht_mean(
         'mean_coef': mean_coef,
         'mean_se': mean_se,
         'mean_asl': mean_asl,
+        'random_state': random_state,
+        'bootstrap_diagnostics': bootstrap_diagnostics,
     })
 
     if not inplace:
@@ -584,6 +656,7 @@ def ht_2d_moments(
     num_boot=10000, 
     verbose=3,
     num_cpus=1,
+    random_state=5,
     **kwargs):
     """
         Performs hypothesis testing for 1D moments.
@@ -624,6 +697,7 @@ def ht_2d_moments(
     # Create partial functions
     ht_funcs = []
     idx_list = []
+    task_random_states = _spawn_task_random_states(random_state, G)
     
     for conv_idx in range(gene_idx_1.shape[0]):
         
@@ -649,6 +723,7 @@ def ht_2d_moments(
                 q=[adata.uns['memento']['group_q'][group] for group in adata.uns['memento']['groups']],
                 _estimator_1d=estimator._get_estimator_1d(adata.uns['memento']['estimator_type']),
                 _estimator_cov=estimator._get_estimator_cov(adata.uns['memento']['estimator_type']),
+                random_state=task_random_states[conv_idx],
                 **kwargs))
     
     # Parallel processing
@@ -674,6 +749,7 @@ def ht_2d_moments(
         'corr_coef': corr_coef,
         'corr_se': corr_se,
         'corr_asl': corr_asl,
+        'random_state': random_state,
     })
 
     if not inplace:

--- a/memento/main.py
+++ b/memento/main.py
@@ -7,21 +7,17 @@
 
 import numpy as np
 import pandas as pd
-from patsy import dmatrix
+import anndata as ad
 import scipy.stats as stats
-from scipy.sparse.csr import csr_matrix
-from scipy.sparse import diags
-import sys
+from scipy.sparse import csr_matrix, diags
 from joblib import Parallel, delayed
 from functools import partial
 import itertools
 import logging
 
-import memento.bootstrap as bootstrap
 import memento.estimator as estimator
 import memento.hypothesis_test as hypothesis_test
 import memento.util as util
-import memento.simulate as simulate
 
 
 def reverse_engineer_counts(adata, n_counts_column='n_counts'):
@@ -38,10 +34,25 @@ def reverse_engineer_counts(adata, n_counts_column='n_counts'):
     
     counts = diags(n_counts)*adata.raw.X.expm1()
     
-    return sc.AnnData(
+    return ad.AnnData(
         X=counts,
         obs=adata.obs,
         var=adata.raw.var)
+
+
+def _get_test_genes_and_indices(adata, treatment_for_gene):
+    """Resolve tested genes once instead of repeatedly scanning ``var_names``."""
+
+    if treatment_for_gene is None:
+        test_genes = adata.var.index.tolist()
+        return test_genes, np.arange(len(test_genes), dtype=int)
+
+    test_genes = list(treatment_for_gene)
+    data_indices = adata.var.index.get_indexer(test_genes)
+    if np.any(data_indices < 0):
+        missing = np.asarray(test_genes, dtype=object)[data_indices < 0]
+        raise ValueError(f"Genes not found in adata.var: {missing.tolist()}")
+    return test_genes, data_indices
 
 
 def setup_memento(
@@ -64,7 +75,7 @@ def setup_memento(
         
     assert adata.obs[q_column].max() < 1
     
-    assert type(adata.X) == csr_matrix, 'please make sure that adata.X is a scipy CSR matrix'
+    assert isinstance(adata.X, csr_matrix), 'please make sure that adata.X is a scipy CSR matrix'
     
     # Setup the memento dictionary in uns
     adata.uns['memento'] = {}
@@ -270,16 +281,6 @@ def compute_1d_moments(
         adata.uns['memento']['gene_rv_filter'] = {group:adata.uns['memento']['gene_rv_filter'][group][overall_gene_mask] for group in group_names}
         adata._inplace_subset_var(overall_gene_mask)
     
-    # Estimate the residual variance transformer for all cells
-    mean_list = []
-    var_list = []
-    for group in adata.uns['memento']['groups']:
-        mean_list.append(adata.uns['memento']['1d_moments'][group][0][adata.uns['memento']['gene_rv_filter'][group]])
-        var_list.append(adata.uns['memento']['1d_moments'][group][1][adata.uns['memento']['gene_rv_filter'][group]])
-    mean_concat = np.concatenate(mean_list)
-    var_concat = np.concatenate(var_list)
-
-#     adata.uns['memento']['mv_regressor'] = {'all':estimator._fit_mv_regressor(mean_concat, var_concat)}
     adata.uns['memento']['mv_regressor'] = {}
     
     # Estimate the residual variance transformer for each group
@@ -300,7 +301,7 @@ def compute_1d_moments(
         
     # If a gene list is given, use that to further filter the moments
     if gene_list is not None:
-        assert type(gene_list) == list
+        assert isinstance(gene_list, list)
         given_gene_mask = np.in1d(adata.var.index.values, gene_list)
 
         adata.uns['memento']['group_cells'] = \
@@ -410,14 +411,11 @@ def ht_1d_moments(
     Nc_list = np.array(Nc_list)
     
     # Get the number of tests and number of genes for those tests
+    test_genes, test_gene_indices = _get_test_genes_and_indices(adata, treatment_for_gene)
     if treatment_for_gene is None:
-        num_tests = treatment.shape[1]*G
-        test_genes = adata.var.index.tolist()
+        num_tests = treatment.shape[1] * G
     else:
-        num_tests = 0
-        for k,v in treatment_for_gene.items():
-            num_tests += len(v)
-        test_genes = list(treatment_for_gene.keys())
+        num_tests = sum(len(treatments) for treatments in treatment_for_gene.values())
         
     # Create dummy covariate DataFrame if one is not given
     if covariate is None:
@@ -427,12 +425,8 @@ def ht_1d_moments(
     mean_coef, mean_se, mean_asl, var_coef, var_se, var_asl = [np.zeros(num_tests)*np.nan for i in range(6)]
     
     ht_funcs = []
-    for idx in range(len(test_genes)):
+    for test_gene, data_idx in zip(test_genes, test_gene_indices):
 
-        # idx is the index of the gene in consideration in test_genes 
-        # data_idx is the index of that gene in consideration in the adata object
-        data_idx = adata.var.index.tolist().index(test_genes[idx])
-        
         ht_funcs.append(
             partial(
                 hypothesis_test._ht_1d,
@@ -440,8 +434,8 @@ def ht_1d_moments(
                 true_res_var=[adata.uns['memento']['1d_moments'][group][2][data_idx] for group in adata.uns['memento']['groups']],
                 cells=[adata.uns['memento']['group_cells'][group][:, data_idx] for group in adata.uns['memento']['groups']],
                 approx_sf=[adata.uns['memento']['approx_size_factor'][group] for group in adata.uns['memento']['groups']],
-                covariate=covariate.values if covariate_for_gene is None else covariate[covariate_for_gene[test_genes[idx]]].values,
-                treatment=treatment.values if treatment_for_gene is None else treatment[treatment_for_gene[test_genes[idx]]].values,
+                covariate=covariate.values if covariate_for_gene is None else covariate[covariate_for_gene[test_gene]].values,
+                treatment=treatment.values if treatment_for_gene is None else treatment[treatment_for_gene[test_gene]].values,
                 Nc_list=Nc_list,
                 num_boot=num_boot,
                 mv_fit=[adata.uns['memento']['mv_regressor'][group] for group in adata.uns['memento']['groups']],
@@ -462,9 +456,17 @@ def ht_1d_moments(
     adata.uns['memento']['1d_ht'] = {}
     if treatment_for_gene is not None:
         adata.uns['memento']['1d_ht']['treatment_for_gene'] = treatment_for_gene
-    attrs = ['test_genes','treatment', 'covariate', 'mean_coef', 'mean_se','mean_asl', 'var_coef', 'var_se','var_asl']
-    for attr in attrs:
-        adata.uns['memento']['1d_ht'][attr] = eval(attr)
+    adata.uns['memento']['1d_ht'].update({
+        'test_genes': test_genes,
+        'treatment': treatment,
+        'covariate': covariate,
+        'mean_coef': mean_coef,
+        'mean_se': mean_se,
+        'mean_asl': mean_asl,
+        'var_coef': var_coef,
+        'var_se': var_se,
+        'var_asl': var_asl,
+    })
 
     if not inplace:
         return adata
@@ -498,14 +500,11 @@ def ht_mean(
     Nc_list = np.array(Nc_list)
     
     # Get the number of tests and number of genes for those tests
+    test_genes, test_gene_indices = _get_test_genes_and_indices(adata, treatment_for_gene)
     if treatment_for_gene is None:
-        num_tests = treatment.shape[1]*G
-        test_genes = adata.var.index.tolist()
+        num_tests = treatment.shape[1] * G
     else:
-        num_tests = 0
-        for k,v in treatment_for_gene.items():
-            num_tests += len(v)
-        test_genes = list(treatment_for_gene.keys())
+        num_tests = sum(len(treatments) for treatments in treatment_for_gene.values())
         
     # Create dummy covariate DataFrame if one is not given
     if covariate is None:
@@ -517,17 +516,17 @@ def ht_mean(
     mean_coef, mean_se, mean_asl = [np.zeros(num_tests)*np.nan for i in range(3)]
     
     get_stats_funcs = []
-    for idx in range(len(test_genes)):
+    for test_gene, data_idx in zip(test_genes, test_gene_indices):
         
         get_stats_funcs.append(
             partial(
                 hypothesis_test._mean_summary_statistics,
-                true_mean=[adata.uns['memento']['1d_moments'][group][0][idx] for group in adata.uns['memento']['groups']],
-                true_res_var=[adata.uns['memento']['1d_moments'][group][2][idx] for group in adata.uns['memento']['groups']],
-                cells=[adata.uns['memento']['group_cells'][group][:, idx] for group in adata.uns['memento']['groups']],
+                true_mean=[adata.uns['memento']['1d_moments'][group][0][data_idx] for group in adata.uns['memento']['groups']],
+                true_res_var=[adata.uns['memento']['1d_moments'][group][2][data_idx] for group in adata.uns['memento']['groups']],
+                cells=[adata.uns['memento']['group_cells'][group][:, data_idx] for group in adata.uns['memento']['groups']],
                 approx_sf=[adata.uns['memento']['approx_size_factor'][group] for group in adata.uns['memento']['groups']],
-                covariate=covariate.values if covariate_for_gene is None else covariate[covariate_for_gene[test_genes[idx]]].values,
-                treatment=treatment.values if treatment_for_gene is None else treatment[treatment_for_gene[test_genes[idx]]].values,
+                covariate=covariate.values if covariate_for_gene is None else covariate[covariate_for_gene[test_gene]].values,
+                treatment=treatment.values if treatment_for_gene is None else treatment[treatment_for_gene[test_gene]].values,
                 Nc_list=Nc_list,
                 num_boot=num_boot,
                 mv_fit=[adata.uns['memento']['mv_regressor'][group] for group in adata.uns['memento']['groups']],
@@ -549,7 +548,10 @@ def ht_mean(
         total_umi=np.array([adata.uns['memento']['total_umi'][g] for g in adata.uns['memento']['groups']])[:, np.newaxis],
         umi_depth=adata.uns['memento']['umi_depth'],
         group_names=get_groups(adata).index.tolist(), 
-        gene_names=adata.var.index.tolist())
+        gene_names=test_genes,
+        num_cpus=num_cpus,
+        treatment_for_gene=treatment_for_gene,
+        covariate_for_gene=covariate_for_gene)
     
     # Save the hypothesis test result
     mean_coef = result_df['coef'].values
@@ -559,9 +561,14 @@ def ht_mean(
     adata.uns['memento']['mean_ht'] = {}
     if treatment_for_gene is not None:
         adata.uns['memento']['mean_ht']['treatment_for_gene'] = treatment_for_gene
-    attrs = ['test_genes','treatment', 'covariate', 'mean_coef', 'mean_se','mean_asl']
-    for attr in attrs:
-        adata.uns['memento']['mean_ht'][attr] = eval(attr)
+    adata.uns['memento']['mean_ht'].update({
+        'test_genes': test_genes,
+        'treatment': treatment,
+        'covariate': covariate,
+        'mean_coef': mean_coef,
+        'mean_se': mean_se,
+        'mean_asl': mean_asl,
+    })
 
     if not inplace:
         return adata
@@ -589,8 +596,6 @@ def ht_2d_moments(
     G = adata.uns['memento']['2d_moments']['gene_idx_1'].shape[0]
     
     # Create design DF
-    design_df_list, Nc_list = [], []
-    
     # Get cell counts
     Nc_list = []
     for group in adata.uns['memento']['groups']:
@@ -624,8 +629,6 @@ def ht_2d_moments(
         
         idx_1 = gene_idx_1[conv_idx]
         idx_2 = gene_idx_2[conv_idx]
-        idx_set = frozenset({idx_1, idx_2})
-    
         if idx_1 == idx_2: # Skip if its the same gene
             continue
             
@@ -665,9 +668,13 @@ def ht_2d_moments(
     adata.uns['memento']['2d_ht'] = {}
     if treatment_for_gene is not None:
         adata.uns['memento']['2d_ht']['treatment_for_gene'] = treatment_for_gene
-    attrs = ['treatment', 'covariate', 'corr_coef', 'corr_se','corr_asl']
-    for attr in attrs:
-        adata.uns['memento']['2d_ht'][attr] = eval(attr)
+    adata.uns['memento']['2d_ht'].update({
+        'treatment': treatment,
+        'covariate': covariate,
+        'corr_coef': corr_coef,
+        'corr_se': corr_se,
+        'corr_asl': corr_asl,
+    })
 
     if not inplace:
         return adata

--- a/memento/simulate.py
+++ b/memento/simulate.py
@@ -1,11 +1,5 @@
-import pandas as pd
-import matplotlib.pyplot as plt
-import scanpy as sc
-import scipy as sp
-import itertools
 import numpy as np
 import scipy.stats as stats
-from sklearn.datasets import make_spd_matrix
 
 import memento.estimator as estimator
 
@@ -63,7 +57,7 @@ def simulate_transcriptomes(
 	dispersions[dispersions < 0] = 1e-5
 	thetas = 1/dispersions
 	
-	if type(norm_cov) == str:
+	if isinstance(norm_cov, str):
 		return stats.nbinom.rvs(*convert_params_nb(means, thetas), size=(n_cells, n_genes))
 		
 	# Generate the copula
@@ -112,15 +106,23 @@ def capture_sampling(transcriptomes, q, q_sq=None, process='hyper', gen=None):
 	return qs, captured_transcriptomes
 
 
-def sequencing_sampling(transcriptomes):
-	
-	observed_transcriptomes = np.zeros(transcriptomes.shape)
+def sequencing_sampling(transcriptomes, num_reads, gen=None):
+	"""Simulate unique molecules observed after sequencing with replacement."""
+
+	transcriptomes = np.asarray(transcriptomes)
+	if np.any(transcriptomes < 0):
+		raise ValueError('transcriptomes must contain non-negative molecule counts')
+	if num_reads < 0:
+		raise ValueError('num_reads must be non-negative')
+
 	num_molecules = transcriptomes.sum()
-	print(num_molecules)
-	
-	for i in range(n_cells):
-		for j in range(n_genes):
-			
-			observed_transcriptomes[i, j] = (stats.binom.rvs(n=int(num_reads), p=1/num_molecules, size=transcriptomes[i, j]) > 0).sum()
-			
-	return observed_transcriptomes
+	if num_molecules == 0 or num_reads == 0:
+		return np.zeros_like(transcriptomes)
+
+	# The old nested loops simulated whether each molecule received at least one
+	# read. Each indicator has this probability, so the sum is binomial and can
+	# be generated for the entire matrix at once.
+	observation_probability = -np.expm1(num_reads * np.log1p(-1 / num_molecules))
+	if gen is None:
+		gen = np.random.default_rng()
+	return gen.binomial(transcriptomes.astype(np.int64), observation_probability)

--- a/memento/util.py
+++ b/memento/util.py
@@ -1,8 +1,5 @@
 import scipy.stats as stats
 import numpy as np
-import time
-import itertools
-import scipy as sp
 import statsmodels.api as sm
 import logging
 from statsmodels.stats.multitest import fdrcorrection
@@ -32,6 +29,8 @@ def _fdrcorrect(pvals):
 
 
 def density_scatterplot(a,b, s=1, cmap='Reds', kde=None):
+    import matplotlib.pyplot as plt
+
     # Calculate the point density
     condition = np.isfinite(a) & np.isfinite(b)
     x = a[condition]
@@ -61,6 +60,8 @@ def robust_linregress(a, b):
     return stats.linregress(x,y)
 
 def robust_hist(x, **kwargs):
+    import matplotlib.pyplot as plt
+
     
     condition = np.isfinite(x)
     plt.hist(x[condition], **kwargs)
@@ -76,13 +77,13 @@ def fit_loglinear(endog, exog, offset, gene, t):
             endog, 
             exog, 
             offset=offset).fit(disp=0)
-    except:
+    except Exception:
         fit = sm.GLM(
             endog,
             exog,
             offset=offset,
             family=sm.families.Gaussian(sm.families.links.Log())).fit()
-        logging.warn(f'fit_loglinear: {gene}, {t} fitted with OLS')
+        logging.warning(f'fit_loglinear: {gene}, {t} fitted with OLS')
     
     return {
         'gene':gene, 

--- a/memento/wrappers.py
+++ b/memento/wrappers.py
@@ -1,5 +1,4 @@
 import memento
-import scipy.stats as stats
 import pandas as pd
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
-scanpy
+anndata>=0.8
+joblib
+numpy
+pandas
+scikit-learn
+scipy
+statsmodels

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='memento-de',
@@ -6,4 +6,15 @@ setup(
     description='Hypothesis testing for scRNA-seq',
     url='https://github.com/yelabucsf/scrna-parameter-estimation.git',
     author='Min Cheol Kim',
-    packages=['memento'])
+    packages=find_packages(),
+    python_requires='>=3.9',
+    install_requires=[
+        'anndata>=0.8',
+        'joblib',
+        'numpy',
+        'pandas',
+        'scikit-learn',
+        'scipy',
+        'statsmodels',
+    ],
+)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -76,6 +76,60 @@ def test_bootstrap_batching_preserves_seeded_results():
     np.testing.assert_allclose(batched[1], unbatched[1], rtol=0, atol=0)
 
 
+def test_explicit_stream_advances_between_groups():
+    expression = sparse.csc_matrix(
+        np.tile(np.arange(5, dtype=np.int64), 100).reshape(-1, 1)
+    )
+    size_factor = np.ones(expression.shape[0])
+    rng = np.random.default_rng(17)
+
+    first = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._pseudobulk,
+        num_boot=20,
+        rng=rng,
+    )
+    second = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._pseudobulk,
+        num_boot=20,
+        rng=rng,
+    )
+
+    assert not np.array_equal(first[0], second[0])
+
+
+def test_explicit_stream_is_reproducible():
+    expression = sparse.csc_matrix(
+        np.tile(np.arange(5, dtype=np.int64), 100).reshape(-1, 1)
+    )
+    size_factor = np.ones(expression.shape[0])
+
+    first = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._pseudobulk,
+        num_boot=20,
+        rng=np.random.default_rng(17),
+    )
+    second = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._pseudobulk,
+        num_boot=20,
+        rng=np.random.default_rng(17),
+    )
+
+    np.testing.assert_array_equal(first[0], second[0])
+    np.testing.assert_array_equal(first[1], second[1])
+
+
 def test_two_dimensional_bootstrap_batching_preserves_seeded_results():
     rng = np.random.default_rng(321)
     expression = sparse.csc_matrix(rng.poisson(1.5, size=(500, 2)))

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,141 @@
+from collections import Counter
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from memento import bootstrap, estimator
+
+
+def _state_counts(expression, size_factor):
+    return Counter(
+        (float(sf), *row)
+        for sf, row in zip(size_factor, np.asarray(expression).tolist())
+    )
+
+
+def test_unique_expr_compresses_exact_states_without_touching_global_rng():
+    expression = np.array(
+        [[0, 1], [0, 1], [2, 0], [2, 0], [2, 0], [4, 3]], dtype=np.int64
+    )
+    size_factor = np.array([100.0, 100.0, 100.0, 200.0, 200.0, 100.0])
+
+    np.random.seed(17)
+    expected_next_random = np.random.random()
+    np.random.seed(17)
+    inv_sf, inv_sf_sq, unique_expression, counts = bootstrap._unique_expr(
+        sparse.csc_matrix(expression), size_factor
+    )
+    actual_next_random = np.random.random()
+
+    actual = Counter()
+    for inv, row, count in zip(inv_sf.ravel(), unique_expression.tolist(), counts):
+        actual[(float(1 / inv), *row)] = int(count)
+    assert actual == _state_counts(expression, size_factor)
+    np.testing.assert_allclose(inv_sf_sq, inv_sf**2)
+    assert actual_next_random == expected_next_random
+
+
+def test_unique_expr_supports_non_integer_custom_estimator_input():
+    expression = np.array([[0.5], [0.5], [1.25], [1.25]])
+    size_factor = np.array([10.0, 10.0, 10.0, 20.0])
+
+    inv_sf, _, unique_expression, counts = bootstrap._unique_expr(
+        sparse.csc_matrix(expression), size_factor
+    )
+
+    actual = Counter()
+    for inv, row, count in zip(inv_sf.ravel(), unique_expression.tolist(), counts):
+        actual[(float(1 / inv), *row)] = int(count)
+    assert actual == _state_counts(expression, size_factor)
+
+
+def test_bootstrap_batching_preserves_seeded_results():
+    rng = np.random.default_rng(123)
+    expression = sparse.csc_matrix(rng.poisson(1.5, size=(500, 1)))
+    size_factor = rng.choice([500.0, 1000.0, 2000.0], size=500)
+
+    unbatched = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._hyper_1d_relative,
+        num_boot=101,
+        batch_size=101,
+    )
+    batched = bootstrap._bootstrap_1d(
+        expression,
+        size_factor,
+        q=0.1,
+        _estimator_1d=estimator._hyper_1d_relative,
+        num_boot=101,
+        batch_size=7,
+    )
+
+    np.testing.assert_allclose(batched[0], unbatched[0], rtol=0, atol=0)
+    np.testing.assert_allclose(batched[1], unbatched[1], rtol=0, atol=0)
+
+
+def test_two_dimensional_bootstrap_batching_preserves_seeded_results():
+    rng = np.random.default_rng(321)
+    expression = sparse.csc_matrix(rng.poisson(1.5, size=(500, 2)))
+    size_factor = rng.choice([500.0, 1000.0, 2000.0], size=500)
+
+    arguments = {
+        "data": expression,
+        "size_factor": size_factor,
+        "q": 0.1,
+        "_estimator_1d": estimator._hyper_1d_relative,
+        "_estimator_cov": estimator._hyper_cov_relative,
+        "num_boot": 101,
+    }
+    unbatched = bootstrap._bootstrap_2d(**arguments, batch_size=101)
+    batched = bootstrap._bootstrap_2d(**arguments, batch_size=7)
+
+    for batched_moment, unbatched_moment in zip(batched, unbatched):
+        np.testing.assert_allclose(batched_moment, unbatched_moment, rtol=0, atol=0)
+
+
+def test_compressed_and_sparse_estimators_are_equivalent():
+    expression = np.array([[0, 1], [2, 0], [2, 0], [4, 3], [0, 1]])
+    matrix = sparse.csc_matrix(expression)
+    size_factor = np.array([100.0, 200.0, 200.0, 100.0, 100.0])
+    inv_sf, inv_sf_sq, unique_expression, counts = bootstrap._unique_expr(
+        matrix, size_factor
+    )
+    frequencies = counts[:, np.newaxis]
+
+    sparse_mean, sparse_var = estimator._hyper_1d_relative(
+        matrix, matrix.shape[0], q=0.1, size_factor=size_factor
+    )
+    compressed_mean, compressed_var = estimator._hyper_1d_relative(
+        (unique_expression, frequencies),
+        matrix.shape[0],
+        q=0.1,
+        size_factor=(inv_sf, inv_sf_sq),
+    )
+    np.testing.assert_allclose(compressed_mean, sparse_mean)
+    np.testing.assert_allclose(compressed_var, sparse_var)
+
+    sparse_cov = estimator._hyper_cov_relative(
+        matrix,
+        matrix.shape[0],
+        size_factor,
+        q=0.1,
+        idx1=np.array([0]),
+        idx2=np.array([1]),
+    )
+    compressed_cov = estimator._hyper_cov_relative(
+        (unique_expression[:, 0:1], unique_expression[:, 1:2], frequencies),
+        matrix.shape[0],
+        (inv_sf, inv_sf_sq),
+        q=0.1,
+    )
+    np.testing.assert_allclose(compressed_cov, sparse_cov)
+
+
+def test_poisson_estimator_names_resolve_to_the_implemented_functions():
+    assert estimator._get_estimator_1d("poi_relative") is estimator._poisson_1d_relative
+    assert estimator._get_estimator_cov("poi_relative") is estimator._poisson_cov_relative
+    with pytest.raises(ValueError, match="Unknown estimator_type"):
+        estimator._get_estimator_1d("not_an_estimator")

--- a/tests/test_hypothesis_test.py
+++ b/tests/test_hypothesis_test.py
@@ -1,7 +1,63 @@
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 from memento import hypothesis_test
+
+
+def test_influence_kurtosis_allocates_more_draws_to_heavy_tails():
+    rng = np.random.default_rng(4)
+    size_factor = np.ones(200)
+    regular = sparse.csc_matrix(rng.poisson(2, size=(200, 1)))
+    heavy = np.zeros((200, 1))
+    heavy[0] = 100
+    heavy = sparse.csc_matrix(heavy)
+
+    regular_draws, _ = hypothesis_test._plan_bootstrap_draws(
+        regular, size_factor, 0.04, 250, 2_000, 50
+    )
+    heavy_draws, _ = hypothesis_test._plan_bootstrap_draws(
+        heavy, size_factor, 0.04, 250, 2_000, 50
+    )
+
+    assert regular_draws >= 250
+    assert heavy_draws > regular_draws
+
+
+def test_adaptive_mean_bootstrap_uses_preplanned_draw_count(monkeypatch):
+    calls = []
+
+    def stable_bootstrap(num_boot, **kwargs):
+        calls.append(num_boot)
+        values = np.tile(np.array([0.9, 1.0, 1.1, 1.0]), num_boot // 4 + 1)
+        return values[:num_boot], np.full(num_boot, 10.0)
+
+    def pseudobulk(*args, **kwargs):
+        raise AssertionError("the estimator is called only by the bootstrap")
+
+    pseudobulk.__name__ = "_pseudobulk"
+    monkeypatch.setattr(
+        hypothesis_test,
+        "_plan_bootstrap_draws",
+        lambda **kwargs: (250, 0.04),
+    )
+    monkeypatch.setattr(hypothesis_test.bootstrap, "_bootstrap_1d", stable_bootstrap)
+    result = hypothesis_test._adaptive_mean_summary_statistics(
+        true_mean=[1.0],
+        true_res_var=[1.0],
+        cells=[None],
+        approx_sf=[None],
+        num_boot=2_000,
+        q=[0.1],
+        _estimator_1d=pseudobulk,
+        rng=np.random.default_rng(1),
+        target_se_rse=0.05,
+        min_boot=250,
+        bootstrap_resolution=250,
+    )
+
+    assert calls == [250]
+    np.testing.assert_array_equal(result[4], [250])
 
 
 def test_cross_coef_matches_weighted_diagonal_reference():

--- a/tests/test_hypothesis_test.py
+++ b/tests/test_hypothesis_test.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pandas as pd
+
+from memento import hypothesis_test
+
+
+def test_cross_coef_matches_weighted_diagonal_reference():
+    rng = np.random.default_rng(11)
+    a = rng.normal(size=(25, 3))
+    b = rng.normal(size=(25, 17))
+    weights = rng.uniform(1, 100, size=25)
+
+    centered_a = a - np.average(a, axis=0, weights=weights)
+    centered_b = b - np.average(b, axis=0, weights=weights)
+    sum_squares = np.average(centered_a**2, axis=0, weights=weights)
+    expected = (
+        centered_a.T.dot(np.diag(weights)).dot(centered_b)
+        / weights.sum()
+        / sum_squares[:, np.newaxis]
+    )
+
+    actual = hypothesis_test._cross_coef(a, b, weights)
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_quasiml_honors_per_gene_treatments_and_covariates(monkeypatch):
+    def capture_fit(**kwargs):
+        return kwargs
+
+    monkeypatch.setattr(hypothesis_test.util, "fit_loglinear", capture_fit)
+    groups = ["group_0", "group_1", "group_2", "group_3"]
+    genes = ["gene_0", "gene_1"]
+    results = [
+        (np.full(4, 0.1), np.full(4, 0.01)),
+        (np.full(4, 0.2), np.full(4, 0.02)),
+    ]
+    treatment = pd.DataFrame(
+        {"tx_0": [0, 0, 1, 1], "tx_1": [0, 1, 0, 1]}, index=groups
+    )
+    covariate = pd.DataFrame(
+        {"intercept": np.ones(4), "batch": [0, 1, 0, 1]}, index=groups
+    )
+
+    fits, _ = hypothesis_test._ht_mean_quasiML(
+        results=results,
+        treatment=treatment,
+        covariate=covariate,
+        total_umi=np.full((4, 1), 1000.0),
+        umi_depth=1000.0,
+        group_names=groups,
+        gene_names=genes,
+        return_fits=True,
+        num_cpus=1,
+        treatment_for_gene={"gene_0": ["tx_0"], "gene_1": ["tx_1"]},
+        covariate_for_gene={"gene_0": ["intercept"], "gene_1": ["intercept", "batch"]},
+    )
+
+    assert [(fit["gene"], fit["t"]) for fit in fits] == [
+        ("gene_0", "tx_0"),
+        ("gene_1", "tx_1"),
+    ]
+    assert fits[0]["exog"].columns.tolist() == ["intercept", "tx_0"]
+    assert fits[1]["exog"].columns.tolist() == ["intercept", "batch", "tx_1"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,6 +79,15 @@ def test_ht_mean_uses_the_requested_gene_index(monkeypatch):
     np.testing.assert_array_equal(captured[0]["cells"][0].toarray().ravel(), [30, 60])
 
 
+def test_parallel_task_seeds_are_reproducible_and_distinct():
+    first = main._spawn_task_random_states(1234, 10)
+    second = main._spawn_task_random_states(1234, 10)
+
+    assert first == second
+    assert len(set(first)) == len(first)
+    assert main._spawn_task_random_states(None, 3) == [None, None, None]
+
+
 def test_moment_pipeline_smoke_test():
     rng = np.random.default_rng(7)
     counts = rng.poisson(rng.uniform(0.5, 4.0, size=(80, 16)))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,109 @@
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import sparse
+
+from memento import main
+
+
+def test_get_test_genes_and_indices_preserves_requested_order():
+    adata = ad.AnnData(
+        X=sparse.csr_matrix(np.zeros((2, 4))),
+        var=pd.DataFrame(index=["g0", "g1", "g2", "g3"]),
+    )
+    treatment_for_gene = {"g3": ["tx"], "g1": ["tx"]}
+
+    genes, indices = main._get_test_genes_and_indices(adata, treatment_for_gene)
+
+    assert genes == ["g3", "g1"]
+    np.testing.assert_array_equal(indices, [3, 1])
+
+
+def test_get_test_genes_and_indices_reports_missing_genes():
+    adata = ad.AnnData(
+        X=sparse.csr_matrix(np.zeros((2, 1))),
+        var=pd.DataFrame(index=["present"]),
+    )
+
+    with pytest.raises(ValueError, match="missing"):
+        main._get_test_genes_and_indices(adata, {"missing": ["tx"]})
+
+
+def test_ht_mean_uses_the_requested_gene_index(monkeypatch):
+    adata = ad.AnnData(
+        X=sparse.csr_matrix(np.zeros((4, 3))),
+        var=pd.DataFrame(index=["g0", "g1", "g2"]),
+    )
+    groups = ["sg^sample_1", "sg^sample_2"]
+    adata.uns["memento"] = {
+        "groups": groups,
+        "estimator_type": "hyper_relative",
+        "1d_moments": {
+            groups[0]: [np.array([1.0, 2.0, 30.0]), np.ones(3), np.ones(3)],
+            groups[1]: [np.array([4.0, 5.0, 60.0]), np.ones(3), np.ones(3)],
+        },
+        "group_cells": {
+            groups[0]: sparse.csc_matrix([[1, 2, 30], [4, 5, 60]]),
+            groups[1]: sparse.csc_matrix([[7, 8, 90], [10, 11, 120]]),
+        },
+        "approx_size_factor": {group: np.ones(2) for group in groups},
+        "mv_regressor": {group: np.ones(3) for group in groups},
+        "group_q": {group: 0.1 for group in groups},
+    }
+    captured = []
+
+    def capture_summary_statistics(**kwargs):
+        captured.append(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        main.hypothesis_test,
+        "_mean_summary_statistics",
+        capture_summary_statistics,
+    )
+
+    treatment = pd.DataFrame({"tx": [0, 1]})
+    result = main.ht_mean(
+        adata,
+        treatment=treatment,
+        treatment_for_gene={"g2": ["tx"]},
+        num_boot=3,
+        num_cpus=1,
+        verbose=0,
+        return_stats=True,
+    )
+
+    assert result == [None]
+    assert captured[0]["true_mean"] == [30.0, 60.0]
+    np.testing.assert_array_equal(captured[0]["cells"][0].toarray().ravel(), [30, 60])
+
+
+def test_moment_pipeline_smoke_test():
+    rng = np.random.default_rng(7)
+    counts = rng.poisson(rng.uniform(0.5, 4.0, size=(80, 16)))
+    obs = pd.DataFrame(
+        {
+            "capture_rate": np.full(80, 0.1),
+            "condition": np.repeat(["control", "treated"], 40),
+        },
+        index=[f"cell_{idx}" for idx in range(80)],
+    )
+    var = pd.DataFrame(index=[f"gene_{idx}" for idx in range(16)])
+    adata = ad.AnnData(X=sparse.csr_matrix(counts), obs=obs, var=var)
+
+    main.setup_memento(
+        adata,
+        q_column="capture_rate",
+        filter_mean_thresh=0.01,
+        trim_percent=0.5,
+        shrinkage=0.1,
+        min_cell_count=10,
+    )
+    main.create_groups(adata, ["condition"])
+    main.compute_1d_moments(adata, min_perc_group=0.0)
+
+    means, variances, cell_counts = main.get_1d_moments(adata)
+    assert means.shape == variances.shape
+    assert means.shape[0] == adata.n_vars
+    assert set(cell_counts.values()) == {40}

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from memento import simulate
+
+
+def test_sequencing_sampling_is_vectorized_and_bounded_by_input_counts():
+    transcriptomes = np.array([[0, 2, 5], [3, 1, 0]])
+    observed = simulate.sequencing_sampling(
+        transcriptomes,
+        num_reads=20,
+        gen=np.random.default_rng(5),
+    )
+
+    assert observed.shape == transcriptomes.shape
+    assert np.issubdtype(observed.dtype, np.integer)
+    assert np.all(observed >= 0)
+    assert np.all(observed <= transcriptomes)
+
+
+def test_sequencing_sampling_handles_empty_input():
+    transcriptomes = np.zeros((2, 3), dtype=int)
+    np.testing.assert_array_equal(
+        simulate.sequencing_sampling(transcriptomes, num_reads=100),
+        transcriptomes,
+    )


### PR DESCRIPTION
Two additions from the codex/adaptive-bootstrap-minimal branch:

Adaptive bootstrap sampling for ht_mean (differential mean expression) — preallocates a per-gene/per-group bootstrap draw count (target_se_rse, min_boot, bootstrap_resolution) based on the pseudobulk estimator's influence kurtosis, instead of always drawing the full num_boot. Draw count is chosen before resampling, so no optional-stopping bias. Scoped intentionally to mean-only testing — confirmed ht_1d_moments (mean+variance) and ht_2d_moments (correlation) do not expose or use these parameters.
Faster unique-count generation (_unique_expr in bootstrap.py) — replaces the old random-projection + np.unique compression with an exact mixed-radix integer encoding, plus batches the multinomial bootstrap draws to bound memory. Applies uniformly to both 1D and 2D bootstrap paths (mean/variance and correlation testing alike), since it's a general performance improvement, not adaptive-specific.

Verified before opening this PR:

High-level API surface unchanged: all setup_memento/create_groups/compute_1d_moments/ht_1d_moments/ht_2d_moments/wrapper signatures are backward compatible; new params are additive with None/backward-compatible defaults.
New adaptive params (target_se_rse, min_boot, bootstrap_resolution) thread through exactly one path: ht_mean → _mean_summary_statistics → _adaptive_mean_summary_statistics. Not reachable from ht_1d_moments/ht_2d_moments.
Adaptive mode also raises ValueError unless estimator_type='pseudobulk', as a second guardrail.
Full test suite passes (19/19: pytest tests/).
Also cleans up two pre-existing dead-code paths unrelated to this feature: a syntax error in memento/estimators/mean.py (unimported, unreachable) and references to nonexistent _hyper_1d_absolute/_poi_1d_absolute estimator functions in estimator.py's dispatch.

Note: ht_mean/ht_1d_moments/ht_2d_moments now default to random_state=5 with independent per-gene RNG streams (SeedSequence.spawn), replacing the old behavior of reusing one fixed-seed generator across every gene. This doesn't change the API, but bootstrap p-values/SEs won't reproduce bit-for-bit against pre-branch runs even with identical arguments.

Drafted by Jimmie.