### PR TITLE
Fix division by zero in _cross_coef for constant design-matrix columns (rebase of #16)

### DIFF
--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -75,7 +75,7 @@ def _compute_asl(perm_diff, approx='norm'):
         Use the generalized pareto distribution to model the tail of the permutation distribution. 
     """
 
-    if np.all(perm_diff == perm_diff.mean()):
+    if np.all(np.isnan(perm_diff)) or np.all(perm_diff == np.nanmean(perm_diff)):
         
         return np.nan
     
@@ -577,12 +577,15 @@ def _cross_coef(A, B, sample_weight):
 
     # Guard against division by zero when a column of A has zero variance
     # (e.g. a constant treatment/covariate column). Checked per-column, since
-    # A may have some constant columns and some non-constant ones; rows of
-    # the result corresponding to a constant column of A are set to 0 rather
-    # than propagating inf/nan. See PR #16 (nkschaefer).
+    # A may have some constant columns and some non-constant ones. Rows of
+    # the result corresponding to a constant column of A are set to NaN
+    # (rather than 0) since the coefficient is genuinely undefined there;
+    # this keeps coef/se/pval consistent downstream in _regress_2d, since
+    # _compute_asl already returns NaN for a degenerate (all-equal) row.
+    # See PR #16 (nkschaefer).
     safe_ssA = np.where(ssA > 0, ssA, 1.0)
     result = numerator / safe_ssA[:, None]
-    result[ssA == 0, :] = 0.0
+    result[ssA == 0, :] = np.nan
     return result
 
 

--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -572,7 +572,6 @@ def _cross_coef(A, B, sample_weight):
     ssA = np.average(A_mA**2, axis=0, weights=sample_weight)
 
     # Finally get corr coeff
-    # Finally get corr coeff
     weighted_B = sample_weight[:, np.newaxis] * B_mB
     numerator = A_mA.T.dot(weighted_B) / sample_weight.sum()
 

--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -572,8 +572,19 @@ def _cross_coef(A, B, sample_weight):
     ssA = np.average(A_mA**2, axis=0, weights=sample_weight)
 
     # Finally get corr coeff
+    # Finally get corr coeff
     weighted_B = sample_weight[:, np.newaxis] * B_mB
-    return A_mA.T.dot(weighted_B) / sample_weight.sum() / ssA[:, None]
+    numerator = A_mA.T.dot(weighted_B) / sample_weight.sum()
+
+    # Guard against division by zero when a column of A has zero variance
+    # (e.g. a constant treatment/covariate column). Checked per-column, since
+    # A may have some constant columns and some non-constant ones; rows of
+    # the result corresponding to a constant column of A are set to 0 rather
+    # than propagating inf/nan. See PR #16 (nkschaefer).
+    safe_ssA = np.where(ssA > 0, ssA, 1.0)
+    result = numerator / safe_ssA[:, None]
+    result[ssA == 0, :] = 0.0
+    return result
 
 
 def _cross_coef_resampled(A, B, sample_weight):

--- a/tests/test_hypothesis_test.py
+++ b/tests/test_hypothesis_test.py
@@ -120,10 +120,14 @@ def test_quasiml_honors_per_gene_treatments_and_covariates(monkeypatch):
     assert fits[1]["exog"].columns.tolist() == ["intercept", "batch", "tx_1"]
 
 
-def test_cross_coef_handles_zero_variance_column_without_nan_or_inf():
+def test_cross_coef_handles_zero_variance_column_without_inf_or_crash():
     # Regression test for PR #16 (nkschaefer): a constant column in A (e.g. a
     # treatment/covariate with no variation across samples) previously caused
     # a division-by-zero in _cross_coef, propagating inf/nan into results.
+    # The coefficient for such a column is genuinely undefined, so it comes
+    # out as NaN (not 0) -- this keeps coef/se/pval consistent downstream in
+    # _regress_2d, since _compute_asl already treats a degenerate row as an
+    # invalid test.
     rng = np.random.default_rng(0)
     n = 50
 
@@ -140,12 +144,36 @@ def test_cross_coef_handles_zero_variance_column_without_nan_or_inf():
         result = hypothesis_test._cross_coef(A, B, weights)
 
     assert result.shape == (2, 3)
-    assert not np.isnan(result).any()
     assert not np.isinf(result).any()
-    # The constant column's row should be zeroed out rather than blown up.
-    np.testing.assert_array_equal(result[0], np.zeros(3))
+    # The constant column's row is undefined -> NaN, not silently zeroed.
+    assert np.all(np.isnan(result[0]))
     # The non-constant column should still produce a real (nonzero) estimate.
+    assert not np.isnan(result[1]).any()
     assert not np.allclose(result[1], 0)
+
+
+def test_compute_asl_returns_nan_for_degenerate_row_from_cross_coef():
+    # Regression test tying together PR #16's fix: a zero-variance treatment
+    # column now produces an all-NaN row from _cross_coef. _compute_asl's
+    # original guard (checking perm_diff == perm_diff.mean()) doesn't catch
+    # an all-NaN array, since NaN != NaN -- it must explicitly check for it.
+    all_nan_row = np.full(21, np.nan)
+
+    with np.errstate(invalid="raise"):
+        pval = hypothesis_test._compute_asl(all_nan_row)
+
+    assert np.isnan(pval)
+
+
+def test_compute_asl_still_handles_all_equal_non_nan_row():
+    # Sanity check that the original all-equal guard (e.g. a row of all
+    # zeros, which _cross_coef could still legitimately produce for reasons
+    # unrelated to the zero-variance guard) is unaffected.
+    all_zero_row = np.zeros(21)
+
+    pval = hypothesis_test._compute_asl(all_zero_row)
+
+    assert np.isnan(pval)
 
 
 def test_cross_coef_matches_manual_calculation_when_no_zero_variance():

--- a/tests/test_hypothesis_test.py
+++ b/tests/test_hypothesis_test.py
@@ -118,3 +118,51 @@ def test_quasiml_honors_per_gene_treatments_and_covariates(monkeypatch):
     ]
     assert fits[0]["exog"].columns.tolist() == ["intercept", "tx_0"]
     assert fits[1]["exog"].columns.tolist() == ["intercept", "batch", "tx_1"]
+
+
+def test_cross_coef_handles_zero_variance_column_without_nan_or_inf():
+    # Regression test for PR #16 (nkschaefer): a constant column in A (e.g. a
+    # treatment/covariate with no variation across samples) previously caused
+    # a division-by-zero in _cross_coef, propagating inf/nan into results.
+    rng = np.random.default_rng(0)
+    n = 50
+
+    A = np.column_stack(
+        [
+            np.ones(n),  # constant column -> zero variance
+            rng.normal(size=n),
+        ]
+    )
+    B = rng.normal(size=(n, 3))
+    weights = np.ones(n)
+
+    with np.errstate(divide="raise", invalid="raise"):
+        result = hypothesis_test._cross_coef(A, B, weights)
+
+    assert result.shape == (2, 3)
+    assert not np.isnan(result).any()
+    assert not np.isinf(result).any()
+    # The constant column's row should be zeroed out rather than blown up.
+    np.testing.assert_array_equal(result[0], np.zeros(3))
+    # The non-constant column should still produce a real (nonzero) estimate.
+    assert not np.allclose(result[1], 0)
+
+
+def test_cross_coef_matches_manual_calculation_when_no_zero_variance():
+    # Sanity check that the zero-variance guard doesn't change results when
+    # it isn't needed.
+    rng = np.random.default_rng(1)
+    n = 40
+
+    A = rng.normal(size=(n, 2))
+    B = rng.normal(size=(n, 2))
+    weights = np.ones(n)
+
+    result = hypothesis_test._cross_coef(A, B, weights)
+
+    A_mA = A - A.mean(axis=0)
+    B_mB = B - B.mean(axis=0)
+    ssA = (A_mA**2).mean(axis=0)
+    expected = (A_mA.T @ B_mB) / n / ssA[:, None]
+
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
Closes #16

Rebases nkschaefer's original fix onto current `master`, which had since refactored `_cross_coef` for efficiency (avoiding building a full diagonal matrix), creating a merge conflict with the original PR.

**Scope:** this only concerns `A`, the design matrix (treatment/covariate columns) passed into `_cross_coef` — not `B` (the bootstrapped gene-gene correlation values). A zero-variance column in `A` means a treatment or covariate variable that's constant across the groups being tested, which can happen either directly or as a side effect of the FWL residualization step in `_regress_2d` (`treatment_tilde = treatment - LinearRegression(...).predict(covariate)`), where an otherwise-varying treatment column can become effectively constant after covariate effects are removed. This is unrelated to genes with constant expression, which are already excluded upstream by `compute_1d_moments`'s mean-threshold filter before reaching this code.

**Changes beyond the original PR:**
- The original guard checked `np.sum(ssA) > 0` globally, so it only prevented the crash when *every* column of `A` was constant. It's now checked per-column via `np.where`, so a single constant column mixed in with normal ones no longer silently produces `inf`/`nan` for just that column.
- The zero-variance guard now emits `NaN` (not `0`) for the affected row. This keeps `coef`/`se`/`pval` consistent downstream in `_regress_2d`: all three now report the test as invalid/undefined for that treatment column, rather than `coef=0`/`se=0` looking like a confidently-estimated null effect while only `pval` (via `_compute_asl`'s own separate degenerate-input check) flagged it as invalid.
- This exposed a latent gap in `_compute_asl`: its existing guard (`np.all(perm_diff == perm_diff.mean())`) does not catch an all-`NaN` row, since `NaN != NaN` under `==`. It fell through to fitting a normal distribution on an empty array, which happened to still resolve to `NaN` but via `scipy` internals and spurious `RuntimeWarning`s rather than an explicit check. Hardened this guard to explicitly check `np.all(np.isnan(perm_diff))` first (using `nanmean` for the existing all-equal check, so it's robust to partially-NaN rows too).

**Tests added** in `tests/test_hypothesis_test.py`:
- `_cross_coef` on a mix of constant/non-constant columns of `A`: confirms no `inf`, confirms the constant column's row is all `NaN`, confirms the non-constant column is unaffected.
- `_cross_coef` matches a manual reference calculation when no column is constant (no behavior change in the common case).
- `_compute_asl` returns `NaN` for an all-`NaN` row (the new guard).
- `_compute_asl` still returns `NaN` for an all-equal-but-non-NaN row (the pre-existing guard, unaffected).

All 27 tests in the suite pass.