### PR TITLE
Bump docs release string to match package version (0.1.2)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'memento'
 copyright = '2025, Min Cheol Kim'
 author = 'YMin Cheol Kim'
-release = '0.1.1'
+release = '0.1.2'
 
 # -- General configuration ---------------------------------------------------
 extensions = [


### PR DESCRIPTION
Closes #51

The README's RTD link (originally reported as broken) was already fixed in a prior commit, pointing to https://memento.readthedocs.io/en/v0.1.2/. I verified that link and its sub-pages (usage guide, estimators, inference, API reference) all resolve with real content.

However, `docs/source/conf.py`'s `release` string was never bumped when v0.1.2 was released, so every doc page's title/footer still read "memento 0.1.1 documentation" -- inconsistent with the URL, the RTD version slug, and `setup.py`'s actual version (0.1.2). This bumps it for consistency.