### PR TITLE
Raise informative error for empty groups in mean-variance regressor fit; bump version to 0.1.3

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 project = 'memento'
 copyright = '2025, Min Cheol Kim'
 author = 'YMin Cheol Kim'
-release = '0.1.2'
+release = '0.1.3'
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/memento/estimator.py
+++ b/memento/estimator.py
@@ -101,13 +101,35 @@ def _estimate_size_factor(data, estimator_type, shrinkage, mask=None, total=Fals
         return size_factor
 
     
-def _fit_mv_regressor(mean, var):
+def _fit_mv_regressor(mean, var, group=None):
     """
         Perform regression of the variance against the mean.
     """
     
     cond = (mean > 0) & (var > 0)
     m, v = np.log(mean[cond]), np.log(var[cond])
+    
+    # np.polyfit only actually raises when given a completely empty input
+    # (m.size == 0) -- it tolerates 1 or 2 points for a degree-2 fit,
+    # producing an underdetermined-but-numeric result rather than an error.
+    # An empty result here usually means this group has too few cells or too
+    # sparse expression for any gene to have both a positive mean and a
+    # positive variance. Raise an informative error in that case rather than
+    # letting np.polyfit fail with an opaque TypeError -- how to handle the
+    # offending group (exclude it, increase min_cell_count, pool it with
+    # another group, etc.) is left to the caller, since that's a modeling
+    # decision specific to their analysis.
+    if m.size == 0:
+        group_desc = f" for group {group!r}" if group is not None else ""
+        raise ValueError(
+            f"No genes with a positive mean and positive variance found "
+            f"to fit the mean-variance regressor{group_desc}. This usually "
+            f"means this group has too few cells or too sparse expression "
+            f"for the current filtering settings. Consider excluding this "
+            f"group, increasing min_cell_count, adjusting "
+            f"filter_mean_thresh, or pooling it with other groups before "
+            f"calling this function."
+        )
     
     poly = np.polyfit(m, v, 2)
     return poly

--- a/memento/main.py
+++ b/memento/main.py
@@ -114,7 +114,7 @@ def setup_memento(
         q=adata.uns['memento']['all_q'],
         size_factor=naive_size_factor)
     all_m[adata.X.mean(axis=0).A1 < filter_mean_thresh] = 0 # mean filter
-    all_res_var = estimator._residual_variance(all_m, all_v, estimator._fit_mv_regressor(all_m, all_v))
+    all_res_var = estimator._residual_variance(all_m, all_v, estimator._fit_mv_regressor(all_m, all_v, group='all cells'))
     
     # Select genes for normalization
     rv_ulim = np.quantile(all_res_var[np.isfinite(all_res_var)], trim_percent)
@@ -306,7 +306,7 @@ def compute_1d_moments(
     for group in adata.uns['memento']['groups']:
         m = adata.uns['memento']['1d_moments'][group][0][adata.uns['memento']['gene_rv_filter'][group]]
         v = adata.uns['memento']['1d_moments'][group][1][adata.uns['memento']['gene_rv_filter'][group]]
-        adata.uns['memento']['mv_regressor'][group] = estimator._fit_mv_regressor(m, v) if adata.uns['memento']['estimator_type'] != 'mean_only' else np.array([0,0,0])
+        adata.uns['memento']['mv_regressor'][group] = estimator._fit_mv_regressor(m, v, group=group) if adata.uns['memento']['estimator_type'] != 'mean_only' else np.array([0,0,0])
     
     # Compute the residual variance
     for group in adata.uns['memento']['groups']:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='memento-de',
-    version='0.1.2',
+    version='0.1.3',
     description='Hypothesis testing for scRNA-seq',
     url='https://github.com/yelabucsf/scrna-parameter-estimation.git',
     author='Min Cheol Kim',

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+
+from memento import estimator
+
+
+def test_fit_mv_regressor_works_with_enough_valid_genes():
+    # Sanity check: normal input is unaffected by the new guard.
+    rng = np.random.default_rng(0)
+    mean = rng.uniform(0.1, 5.0, size=50)
+    var = mean * rng.uniform(1.0, 3.0, size=50)  # roughly overdispersed
+
+    poly = estimator._fit_mv_regressor(mean, var)
+
+    assert poly.shape == (3,)  # degree-2 polyfit returns 3 coefficients
+
+
+def test_fit_mv_regressor_raises_informative_error_on_empty_input():
+    # Regression test for issue #29: a group with no genes passing
+    # (mean > 0) & (var > 0) -- e.g. a donor with too few cells or too low
+    # sequencing depth -- previously crashed deep inside np.polyfit with an
+    # opaque "TypeError: expected non-empty vector for x". It should now
+    # raise a clear, actionable error instead.
+    mean = np.zeros(20)
+    var = np.zeros(20)
+
+    with pytest.raises(ValueError, match="No genes with a positive mean"):
+        estimator._fit_mv_regressor(mean, var)
+
+
+def test_fit_mv_regressor_error_names_the_offending_group():
+    # The error should identify which group failed, since this is raised
+    # from within a per-group loop (compute_1d_moments) where the caller
+    # needs to know which group to investigate.
+    mean = np.zeros(20)
+    var = np.zeros(20)
+
+    with pytest.raises(ValueError, match="sg\\^C"):
+        estimator._fit_mv_regressor(mean, var, group="sg^C")
+
+
+def test_fit_mv_regressor_tolerates_few_but_nonzero_valid_genes():
+    # np.polyfit itself tolerates 1-2 points for a degree-2 fit (producing
+    # an underdetermined-but-numeric result), so the new guard should only
+    # trigger on genuinely empty input, not merely small input -- this
+    # preserves existing (if statistically weak) behavior for edge cases
+    # that previously "worked".
+    mean = np.array([1.0, 2.0])
+    var = np.array([1.5, 3.0])
+
+    poly = estimator._fit_mv_regressor(mean, var)
+
+    assert poly.shape == (3,)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -192,3 +192,48 @@ def test_binary_test_1d_treatment_col_is_numeric_end_to_end():
 
     assert pd.api.types.is_numeric_dtype(sample_meta["condition"])
     assert set(sample_meta["condition"].unique()) == {0.0, 1.0}
+
+
+def test_compute_1d_moments_raises_informative_error_for_sparse_group():
+    # End-to-end regression test for issue #29: a many-donor covariate
+    # setup where one donor/group has too few genes with a positive mean
+    # and positive variance (e.g. very low sequencing depth for that
+    # sample) previously crashed the entire compute_1d_moments call with an
+    # opaque "TypeError: expected non-empty vector for x" from deep inside
+    # np.polyfit. It should now raise a clear ValueError naming the
+    # offending group instead.
+    rng = np.random.default_rng(0)
+    n_genes = 20
+
+    def make_block(n_cells, lam):
+        return rng.poisson(lam, size=(n_cells, n_genes))
+
+    # Two healthy donors, and one donor that clears the min_cell_count
+    # filter (15 >= default 10) but has all-zero counts, so no gene has a
+    # positive mean/variance within that group.
+    counts = np.vstack(
+        [
+            make_block(30, 3.0),
+            make_block(30, 3.0),
+            np.zeros((15, n_genes), dtype=int),
+        ]
+    )
+    obs = pd.DataFrame(
+        {
+            "capture_rate": np.full(75, 0.1),
+            "donor": ["A"] * 30 + ["B"] * 30 + ["C"] * 15,
+        },
+        index=[f"cell_{idx}" for idx in range(75)],
+    )
+    var = pd.DataFrame(index=[f"gene_{idx}" for idx in range(n_genes)])
+    adata = ad.AnnData(X=sparse.csr_matrix(counts), obs=obs, var=var)
+
+    main.setup_memento(adata, q_column="capture_rate", filter_mean_thresh=0.0)
+    main.create_groups(adata, ["donor"])
+
+    # Donor C survives create_groups' min_cell_count filter, so the crash
+    # site is compute_1d_moments' per-group mean-variance regressor fit.
+    assert "sg^C" in adata.uns["memento"]["groups"]
+
+    with pytest.raises(ValueError, match="sg\\^C"):
+        main.compute_1d_moments(adata, min_perc_group=0.3)


### PR DESCRIPTION
Fixes #29

`compute_1d_moments` loops over every group defined by `create_groups` (potentially many, e.g. one per donor in a many-donor covariate setup, exactly #29's scenario) and calls `_fit_mv_regressor` per group. If a group has no genes with both a positive mean and positive variance -- e.g. a donor that clears the `min_cell_count` filter but has very low sequencing depth -- `np.polyfit` crashes on the resulting empty array with an opaque `TypeError: expected non-empty vector for x`, giving no indication of which group or why.

`_fit_mv_regressor` now raises a clear `ValueError` naming the offending group and explaining likely causes, when given empty input. This is intentionally just better error reporting: how to handle the offending group (exclude it, increase `min_cell_count`, adjust `filter_mean_thresh`, pool it with another group, etc.) is left to the caller, since that's an analysis-specific modeling decision, not something the fix imposes.

The guard only triggers on genuinely empty input (`m.size == 0`), since `np.polyfit` itself already tolerates 1-2 points for a degree-2 fit (producing an underdetermined-but-numeric result rather than an error) -- confirmed this narrower scope doesn't change behavior for existing small-sample usage.

**Also bumps the package version to 0.1.3** (`setup.py` and `docs/source/conf.py`). The currently-published `0.1.2` wheel on PyPI predates a later commit that added `install_requires`, so a fresh `pip install memento-de` today installs with zero declared dependencies and fails to import (`ModuleNotFoundError: No module named 'numpy'`) -- verified this directly in a clean venv. See #28. Publishing `0.1.3` will ship the already-present `install_requires` along with this fix. Actual publishing to PyPI is a separate manual step.

**Tests:** `tests/test_estimator.py` (new file) covers the unit-level behavior (empty input raises with group name; 1-2 point input still works, matching `np.polyfit`'s own tolerance). `tests/test_main.py` adds an end-to-end reproduction via the real `setup_memento` -> `create_groups` -> `compute_1d_moments` pipeline with a genuinely all-zero-count group, confirming the informative error surfaces through the real code path. Full suite (32 tests) passes.