### PR TITLE
Update README docs link to v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install memento-de
 
 Memento only has one dependency, which is `scanpy`. Any version of python > 3.9 should work.
 
-For more information, please refer to the documentation [here](https://memento.readthedocs.io/en/v0.1.2/)!
+For more information, please refer to the documentation [here](https://memento.readthedocs.io/en/v0.1.3/)!
 
 NOTE:
 


### PR DESCRIPTION
v0.1.3 is now live on ReadTheDocs -- verified directly (HTTP 200, correct version metadata, all internal links resolving) at https://memento.readthedocs.io/en/v0.1.3/