### PR TITLE
Pre-filter constant-variance treatment columns; quiet degenerate bootstrap iterations

### DIFF
--- a/memento/hypothesis_test.py
+++ b/memento/hypothesis_test.py
@@ -598,7 +598,18 @@ def _cross_coef_resampled(A, B, sample_weight):
     ssA = (A_mA**2*sample_weight[:, :, np.newaxis]).sum(axis=0)/sample_weight.sum(axis=0)[:, np.newaxis]
 #     ssB = ((B_mB**2*sample_weight).sum(axis=0)/sample_weight.sum(axis=0))[:, np.newaxis]
 
-    beta = np.einsum('ijk,ij->jk', A_mA * sample_weight[:, :, np.newaxis], B_mB).T/sample_weight.sum(axis=0) / ssA.T
+    # A given bootstrap iteration can, purely by chance, resample a subset
+    # of replicates for which a (globally non-constant) treatment column
+    # ends up with zero variance -- e.g. a small donor cohort happening to
+    # draw the same genotype repeatedly. The resulting coefficient is
+    # genuinely undefined for that iteration, which is fine (well-tolerated
+    # by the downstream nanmean/nanstd aggregation), but computing it via an
+    # actual division by zero triggers noisy RuntimeWarnings on every
+    # occurrence, which adds up across a large scan. Avoid the division
+    # entirely and substitute NaN directly instead.
+    safe_ssA = np.where(ssA > 0, ssA, 1.0)
+    beta = np.einsum('ijk,ij->jk', A_mA * sample_weight[:, :, np.newaxis], B_mB).T/sample_weight.sum(axis=0) / safe_ssA.T
+    beta[ssA.T == 0] = np.nan
 #     r = beta * np.sqrt(ssA).T/np.sqrt(ssB).T
 #     num_cells_per_boot = sample_weight.sum(axis=0)
 #     t = np.sqrt(num_cells_per_boot-2)*r/np.sqrt(1-r**2)
@@ -636,40 +647,33 @@ def _regress_1d(
 
         return [np.zeros(treatment.shape[1])*np.nan]*5
     
-    if (treatment == 1).mean()==1:
-        
-        mean_coef = np.average(boot_mean, axis=0, weights=Nc_list).reshape(1, -1)
-        var_coef = np.average(boot_var, axis=0, weights=Nc_list).reshape(1, -1)
-        
+    boot_mean_tilde = boot_mean - LinearRegression(n_jobs=1).fit(covariate,boot_mean, Nc_list).predict(covariate)
+    boot_var_tilde = boot_var - LinearRegression(n_jobs=1).fit(covariate,boot_var, Nc_list).predict(covariate)
+    treatment_tilde = treatment - LinearRegression(n_jobs=1).fit(covariate, treatment, Nc_list).predict(covariate)
+
+    if resample_rep:            
+
+        replicate_assignment = _choice(
+            rng, num_rep, size=(num_rep, num_boot)
+        )
+        replicate_assignment[:, 0] = np.arange(num_rep)
+        b_iter_assignment = _choice(
+            rng, num_boot, size=(num_rep, num_boot)
+        ) + 1
+        b_iter_assignment[:, 0] = 0
+
+        boot_mean_resampled = boot_mean_tilde[(replicate_assignment, b_iter_assignment)]
+        boot_var_resampled = boot_var_tilde[(replicate_assignment, b_iter_assignment)]
+        treatment_resampled = treatment_tilde[replicate_assignment]
+        weights_resampled = Nc_list[replicate_assignment]
+
+        mean_coef = _cross_coef_resampled(treatment_resampled, boot_mean_resampled, weights_resampled)
+        var_coef = _cross_coef_resampled(treatment_resampled, boot_var_resampled, weights_resampled)    
+
     else:
 
-        boot_mean_tilde = boot_mean - LinearRegression(n_jobs=1).fit(covariate,boot_mean, Nc_list).predict(covariate)
-        boot_var_tilde = boot_var - LinearRegression(n_jobs=1).fit(covariate,boot_var, Nc_list).predict(covariate)
-        treatment_tilde = treatment - LinearRegression(n_jobs=1).fit(covariate, treatment, Nc_list).predict(covariate)
-
-        if resample_rep:            
-
-            replicate_assignment = _choice(
-                rng, num_rep, size=(num_rep, num_boot)
-            )
-            replicate_assignment[:, 0] = np.arange(num_rep)
-            b_iter_assignment = _choice(
-                rng, num_boot, size=(num_rep, num_boot)
-            ) + 1
-            b_iter_assignment[:, 0] = 0
-
-            boot_mean_resampled = boot_mean_tilde[(replicate_assignment, b_iter_assignment)]
-            boot_var_resampled = boot_var_tilde[(replicate_assignment, b_iter_assignment)]
-            treatment_resampled = treatment_tilde[replicate_assignment]
-            weights_resampled = Nc_list[replicate_assignment]
-
-            mean_coef = _cross_coef_resampled(treatment_resampled, boot_mean_resampled, weights_resampled)
-            var_coef = _cross_coef_resampled(treatment_resampled, boot_var_resampled, weights_resampled)    
-
-        else:
-
-            mean_coef = _cross_coef(treatment_tilde, boot_mean_tilde, Nc_list)
-            var_coef = _cross_coef(treatment_tilde, boot_var_tilde, Nc_list)
+        mean_coef = _cross_coef(treatment_tilde, boot_mean_tilde, Nc_list)
+        var_coef = _cross_coef(treatment_tilde, boot_var_tilde, Nc_list)
 
     mean_asl = np.apply_along_axis(lambda x: _compute_asl(x, **kwargs), 1, mean_coef)
     var_asl = np.apply_along_axis(lambda x: _compute_asl(x, **kwargs), 1, var_coef)
@@ -778,35 +782,29 @@ def _regress_2d(
 
         return [np.zeros(treatment.shape[1])*np.nan]*5
     
-    if (treatment == 1).mean()==1:
-        
-        corr_coef = np.average(boot_corr, axis=0, weights=Nc_list).reshape(1,-1)
-        
+    boot_corr_tilde = boot_corr - LinearRegression(n_jobs=1).fit(covariate, boot_corr, Nc_list).predict(covariate)
+    treatment_tilde = treatment - LinearRegression(n_jobs=1).fit(covariate, treatment, Nc_list).predict(covariate)
+
+    if resample_rep:
+
+        replicate_assignment = _choice(
+            rng, num_rep, size=(num_rep, num_boot)
+        )
+        replicate_assignment[:, 0] = np.arange(num_rep)
+        b_iter_assignment = _choice(
+            rng, num_boot, size=(num_rep, num_boot)
+        ) + 1
+        b_iter_assignment[:, 0] = 0
+
+        boot_corr_resampled = boot_corr_tilde[(replicate_assignment, b_iter_assignment)]
+        treatment_resampled = treatment_tilde[replicate_assignment]
+        weights_resampled = Nc_list[replicate_assignment]
+
+        corr_coef = _cross_coef_resampled(treatment_resampled, boot_corr_resampled, weights_resampled)
+
     else:
 
-        boot_corr_tilde = boot_corr - LinearRegression(n_jobs=1).fit(covariate, boot_corr, Nc_list).predict(covariate)
-        treatment_tilde = treatment - LinearRegression(n_jobs=1).fit(covariate, treatment, Nc_list).predict(covariate)
-
-        if resample_rep:
-
-            replicate_assignment = _choice(
-                rng, num_rep, size=(num_rep, num_boot)
-            )
-            replicate_assignment[:, 0] = np.arange(num_rep)
-            b_iter_assignment = _choice(
-                rng, num_boot, size=(num_rep, num_boot)
-            ) + 1
-            b_iter_assignment[:, 0] = 0
-
-            boot_corr_resampled = boot_corr_tilde[(replicate_assignment, b_iter_assignment)]
-            treatment_resampled = treatment_tilde[replicate_assignment]
-            weights_resampled = Nc_list[replicate_assignment]
-
-            corr_coef = _cross_coef_resampled(treatment_resampled, boot_corr_resampled, weights_resampled)
-
-        else:
-
-            corr_coef = _cross_coef(treatment_tilde, boot_corr_tilde, Nc_list)
+        corr_coef = _cross_coef(treatment_tilde, boot_corr_tilde, Nc_list)
 
     corr_asl = np.apply_along_axis(lambda x: _compute_asl(x, **kwargs), 1, corr_coef)
 

--- a/memento/main.py
+++ b/memento/main.py
@@ -506,6 +506,16 @@ def ht_1d_moments(
         Nc_list.append(adata.uns['memento']['group_cells'][group].shape[0])
     Nc_list = np.array(Nc_list)
     
+    # Validate that every requested gene actually exists BEFORE filtering
+    # out constant treatment columns below. Otherwise a gene that doesn't
+    # exist in adata.var (e.g. a typo, or a gene already excluded upstream
+    # by the expression filter) could get silently dropped by the
+    # constant-treatment filter first -- if its assigned columns happen to
+    # all be constant -- masking the real problem with a misleading
+    # "nothing to test" warning instead of a clear "gene not found" error.
+    if treatment_for_gene is not None:
+        _get_test_genes_and_indices(adata, treatment_for_gene)
+    
     # Drop treatment columns with zero variance across groups (e.g. a
     # monomorphic SNP genotype) before any bootstrap computation runs --
     # there is nothing to test for a treatment that never varies.

--- a/memento/main.py
+++ b/memento/main.py
@@ -13,6 +13,7 @@ from scipy.sparse import csr_matrix, diags
 from joblib import Parallel, delayed
 from functools import partial
 import itertools
+import warnings
 import logging
 
 import memento.estimator as estimator
@@ -53,6 +54,81 @@ def _get_test_genes_and_indices(adata, treatment_for_gene):
         missing = np.asarray(test_genes, dtype=object)[data_indices < 0]
         raise ValueError(f"Genes not found in adata.var: {missing.tolist()}")
     return test_genes, data_indices
+
+
+def _drop_constant_treatment_columns(treatment, treatment_for_gene):
+    """
+    Identify treatment columns with zero variance across the groups being
+    tested (e.g. a monomorphic SNP genotype in an eQTL scan). There is
+    nothing to estimate for such a column -- the treatment never varies, so
+    no association with it can be detected -- and running the full
+    bootstrap/regression machinery on it only produces numerical warnings
+    and uninformative NaN-like output. These are dropped before any
+    bootstrap computation runs, rather than being run and reported as an
+    invalid result.
+
+    If `treatment_for_gene` is None, `treatment`'s columns apply uniformly
+    to every gene: returns the list of constant column names to drop from
+    `treatment` itself.
+
+    If `treatment_for_gene` is provided, each gene may test a different
+    subset of `treatment`'s columns: returns a filtered copy of
+    `treatment_for_gene` with constant columns removed from each gene's
+    list (dropping the gene entirely if none of its columns remain), and a
+    list of (gene, column) pairs that were dropped, for a summary warning.
+    """
+    constant_cols = [
+        col for col in treatment.columns if treatment[col].nunique(dropna=True) <= 1
+    ]
+
+    if treatment_for_gene is None:
+        return None, constant_cols
+
+    if not constant_cols:
+        return treatment_for_gene, []
+
+    constant_col_set = set(constant_cols)
+    filtered = {}
+    dropped = []
+    for gene, cols in treatment_for_gene.items():
+        kept = [c for c in cols if c not in constant_col_set]
+        dropped.extend((gene, c) for c in cols if c in constant_col_set)
+        if kept:
+            filtered[gene] = kept
+        # Genes with zero remaining columns are silently dropped, matching
+        # how genes that fail the expression filter are excluded elsewhere.
+
+    return filtered, dropped
+
+
+def _prefilter_constant_treatment(treatment, treatment_for_gene):
+    """
+    Applies `_drop_constant_treatment_columns` and warns with a short
+    summary if anything was dropped. Returns the (possibly filtered)
+    `treatment` and `treatment_for_gene` to use going forward.
+    """
+    if treatment_for_gene is None:
+        _, constant_cols = _drop_constant_treatment_columns(treatment, None)
+        if constant_cols:
+            warnings.warn(
+                f"Dropping treatment column(s) with zero variance across "
+                f"groups (nothing to test): {constant_cols}. These will not "
+                f"appear in the results."
+            )
+            treatment = treatment.drop(columns=constant_cols)
+        return treatment, treatment_for_gene
+
+    filtered, dropped = _drop_constant_treatment_columns(treatment, treatment_for_gene)
+    if dropped:
+        preview = dropped[:5]
+        suffix = " ..." if len(dropped) > 5 else ""
+        warnings.warn(
+            f"Dropping {len(dropped)} gene/treatment-column pair(s) with "
+            f"zero variance across groups (nothing to test); these will not "
+            f"appear in the results. Examples: {preview}{suffix}"
+        )
+    return treatment, filtered
+
 
 
 def _spawn_task_random_states(random_state, n_tasks):
@@ -430,6 +506,11 @@ def ht_1d_moments(
         Nc_list.append(adata.uns['memento']['group_cells'][group].shape[0])
     Nc_list = np.array(Nc_list)
     
+    # Drop treatment columns with zero variance across groups (e.g. a
+    # monomorphic SNP genotype) before any bootstrap computation runs --
+    # there is nothing to test for a treatment that never varies.
+    treatment, treatment_for_gene = _prefilter_constant_treatment(treatment, treatment_for_gene)
+    
     # Get the number of tests and number of genes for those tests
     test_genes, test_gene_indices = _get_test_genes_and_indices(adata, treatment_for_gene)
     if treatment_for_gene is None:
@@ -682,13 +763,18 @@ def ht_2d_moments(
         Nc_list.append(adata.uns['memento']['group_cells'][group].shape[0])
     Nc_list = np.array(Nc_list)
         
+    # Drop treatment columns with zero variance across groups (e.g. a
+    # monomorphic SNP genotype) before any bootstrap computation runs --
+    # there is nothing to test for a treatment that never varies.
+    treatment, treatment_for_gene = _prefilter_constant_treatment(treatment, treatment_for_gene)
+        
     # Get the number of tests
     if treatment_for_gene is None:
         num_tests = treatment.shape[1]*G
     else:
         num_tests = 0
         for pair in adata.uns['memento']['2d_moments']['gene_pairs']:
-            num_tests += len(treatment_for_gene[pair])
+            num_tests += len(treatment_for_gene.get(pair, []))
             
     # Create dummy covariate DataFrame if one is not given
     if covariate is None:
@@ -711,6 +797,10 @@ def ht_2d_moments(
         idx_1 = gene_idx_1[conv_idx]
         idx_2 = gene_idx_2[conv_idx]
         if idx_1 == idx_2: # Skip if its the same gene
+            continue
+        if treatment_for_gene is not None and (adata.var.index[idx_1], adata.var.index[idx_2]) not in treatment_for_gene:
+            # All of this pair's treatment columns were dropped by the
+            # zero-variance pre-filter above -- nothing left to test.
             continue
             
         # Save the indices
@@ -923,7 +1013,7 @@ def get_2d_ht_result(adata):
     """
     if 'treatment_for_gene' in adata.uns['memento']['2d_ht']:
         result_df = pd.concat([
-            pd.DataFrame(itertools.product([pair], adata.uns['memento']['2d_ht']['treatment_for_gene'][pair]), 
+            pd.DataFrame(itertools.product([pair], adata.uns['memento']['2d_ht']['treatment_for_gene'].get(pair, [])), 
                 columns=['pair', 'tx']) for pair in adata.uns['memento']['2d_moments']['gene_pairs']])
         result_df = pd.concat([  pd.DataFrame(result_df['pair'].tolist(), columns=['gene_1', 'gene_2']), result_df[['tx']].reset_index(drop=True)  ], axis=1)
     else:

--- a/memento/main.py
+++ b/memento/main.py
@@ -131,6 +131,23 @@ def _prefilter_constant_treatment(treatment, treatment_for_gene):
 
 
 
+def _validate_gene_pairs_exist(adata, treatment_for_gene):
+    """
+    Raise a clear error if `treatment_for_gene` references a gene pair
+    that wasn't computed via `compute_2d_moments`, rather than letting it
+    be silently ignored (e.g. by the task-building loop simply never
+    looking it up) -- mirroring `_get_test_genes_and_indices`'s existence
+    check for the 1D case.
+    """
+    valid_pairs = set(adata.uns['memento']['2d_moments']['gene_pairs'])
+    missing = [pair for pair in treatment_for_gene if pair not in valid_pairs]
+    if missing:
+        raise ValueError(
+            f"Gene pairs not found in computed 2d moments (did you call "
+            f"compute_2d_moments with these pairs first?): {missing}"
+        )
+
+
 def _spawn_task_random_states(random_state, n_tasks):
     """Create reproducible per-task seeds independent of worker scheduling."""
 
@@ -773,6 +790,14 @@ def ht_2d_moments(
         Nc_list.append(adata.uns['memento']['group_cells'][group].shape[0])
     Nc_list = np.array(Nc_list)
         
+    # Validate that every requested gene pair was actually computed BEFORE
+    # filtering out constant treatment columns below, for the same reason
+    # as ht_1d_moments: otherwise a nonexistent/mistyped pair could get
+    # silently dropped by the constant-treatment filter first if its
+    # columns happen to all be constant, masking the real problem.
+    if treatment_for_gene is not None:
+        _validate_gene_pairs_exist(adata, treatment_for_gene)
+    
     # Drop treatment columns with zero variance across groups (e.g. a
     # monomorphic SNP genotype) before any bootstrap computation runs --
     # there is nothing to test for a treatment that never varies.

--- a/memento/main.py
+++ b/memento/main.py
@@ -972,10 +972,11 @@ def get_1d_ht_result(adata):
     
     
     if 'treatment_for_gene' in adata.uns['memento']['1d_ht']:
-        result_df = pd.concat([
+        frames = [
             pd.DataFrame(
                 itertools.product([g], adata.uns['memento']['1d_ht']['treatment_for_gene'][g]), 
-                columns=['gene', 'tx']) for g in adata.uns['memento']['1d_ht']['test_genes']])
+                columns=['gene', 'tx']) for g in adata.uns['memento']['1d_ht']['test_genes']]
+        result_df = pd.concat(frames) if frames else pd.DataFrame(columns=['gene', 'tx'])
     else:
         result_df = pd.DataFrame(itertools.product(adata.uns['memento']['1d_ht']['test_genes'], adata.uns['memento']['1d_ht']['treatment'].columns), columns=['gene', 'tx'])
     result_df['de_coef'] = adata.uns['memento']['1d_ht']['mean_coef']
@@ -1012,9 +1013,10 @@ def get_2d_ht_result(adata):
         Getter function for 2d HT result
     """
     if 'treatment_for_gene' in adata.uns['memento']['2d_ht']:
-        result_df = pd.concat([
+        frames = [
             pd.DataFrame(itertools.product([pair], adata.uns['memento']['2d_ht']['treatment_for_gene'].get(pair, [])), 
-                columns=['pair', 'tx']) for pair in adata.uns['memento']['2d_moments']['gene_pairs']])
+                columns=['pair', 'tx']) for pair in adata.uns['memento']['2d_moments']['gene_pairs']]
+        result_df = pd.concat(frames) if frames else pd.DataFrame(columns=['pair', 'tx'])
         result_df = pd.concat([  pd.DataFrame(result_df['pair'].tolist(), columns=['gene_1', 'gene_2']), result_df[['tx']].reset_index(drop=True)  ], axis=1)
     else:
         result_df = pd.DataFrame(itertools.product(adata.uns['memento']['2d_moments']['gene_pairs'], adata.uns['memento']['2d_ht']['treatment'].columns), 

--- a/tests/test_hypothesis_test.py
+++ b/tests/test_hypothesis_test.py
@@ -194,3 +194,31 @@ def test_cross_coef_matches_manual_calculation_when_no_zero_variance():
     expected = (A_mA.T @ B_mB) / n / ssA[:, None]
 
     np.testing.assert_allclose(result, expected)
+
+
+def test_cross_coef_resampled_handles_zero_variance_iteration_without_warning():
+    # Regression test for issue #38: unlike a treatment column that is
+    # constant across the whole dataset (filtered out upstream before this
+    # function is ever called), a single bootstrap iteration can, purely by
+    # chance, resample a subset for which an otherwise-varying column ends
+    # up with zero variance. The resulting coefficient is genuinely
+    # undefined for that one iteration (fine, tolerated downstream), but it
+    # should come out as a clean NaN rather than triggering a
+    # RuntimeWarning from an actual division by zero.
+    rng = np.random.default_rng(0)
+    num_rep, num_boot, n_treatment_cols = 5, 4, 1
+
+    A = rng.normal(size=(num_rep, num_boot, n_treatment_cols))
+    A[:, 1, :] = 7.0  # bootstrap iteration 1 is degenerate: zero variance
+    B = rng.normal(size=(num_rep, num_boot))
+    sample_weight = np.ones((num_rep, num_boot))
+
+    with np.errstate(divide="raise", invalid="raise"):
+        beta = hypothesis_test._cross_coef_resampled(A, B, sample_weight)
+
+    assert beta.shape == (n_treatment_cols, num_boot)
+    assert np.all(np.isnan(beta[:, 1]))
+    # Other iterations, with genuine variance, are unaffected.
+    assert not np.isnan(beta[:, 0]).any()
+    assert not np.isnan(beta[:, 2]).any()
+    assert not np.isnan(beta[:, 3]).any()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -454,3 +454,127 @@ def test_ht_2d_moments_drops_pair_when_all_treatment_columns_constant():
         (result["gene_1"] == g1) & (result["gene_2"] == g0)
     )
     assert set(result.loc[pair_01_mask, "tx"]) == {"snp_normal"}
+
+
+def test_get_1d_ht_result_returns_empty_frame_when_all_genes_dropped():
+    # If every gene passed to ht_1d_moments ends up with zero surviving
+    # treatment columns (e.g. an eQTL scan where every SNP happens to be
+    # monomorphic in this cohort), get_1d_ht_result should return a clean,
+    # well-formed empty DataFrame rather than crashing on pd.concat([]).
+    rng = np.random.default_rng(3)
+    adata = _build_donor_adata(rng)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    treatment = pd.DataFrame({"snp_monomorphic": np.zeros(n_donors)}, index=groups)
+    treatment_for_gene = {adata.var.index[0]: ["snp_monomorphic"]}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        main.ht_1d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=100,
+            verbose=0,
+            num_cpus=1,
+        )
+
+    result = main.get_1d_ht_result(adata)
+
+    assert result.shape == (0, 8)
+    assert list(result.columns) == [
+        "gene", "tx", "de_coef", "de_se", "de_pval", "dv_coef", "dv_se", "dv_pval",
+    ]
+
+
+def test_get_2d_ht_result_returns_empty_frame_when_only_pair_dropped():
+    rng = np.random.default_rng(4)
+    adata = _build_donor_adata(rng, n_genes=20)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    surviving = adata.uns["memento"]["gene_list"]
+    g0, g1 = surviving[0], surviving[1]
+    main.compute_2d_moments(adata, [(g0, g1)])
+
+    treatment = pd.DataFrame({"snp_monomorphic": np.zeros(n_donors)}, index=groups)
+    treatment_for_gene = {(g0, g1): ["snp_monomorphic"]}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        main.ht_2d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=100,
+            verbose=0,
+            num_cpus=1,
+            resample_rep=True,
+        )
+
+    result = main.get_2d_ht_result(adata)
+
+    assert result.shape == (0, 6)
+    assert list(result.columns) == ["gene_1", "gene_2", "tx", "corr_coef", "corr_se", "corr_pval"]
+
+
+def test_ht_1d_moments_result_alignment_is_reproducible_with_mixed_dropouts():
+    # Regression test for the concern that per-gene treatment-column
+    # filtering could misalign get_1d_ht_result's (gene, tx) rows against
+    # the underlying flat coefficient arrays. Builds a scenario with
+    # several genes, each with a DIFFERENT number of treatment columns
+    # dropped (0, 1, all), and confirms that re-running the exact same
+    # call is bit-for-bit reproducible -- which would not hold if rows
+    # were misaligned relative to the coefficient arrays, since a shift
+    # would pull in a different (still plausible-looking, but wrong)
+    # value each run only if randomness differed, but here the random
+    # seeding is fully determined by call structure, so any misalignment
+    # bug would show up as a structural (index) mismatch, not just noise.
+    def run():
+        rng = np.random.default_rng(7)
+        adata = _build_donor_adata(rng, n_genes=50, n_donors=25)
+        groups = adata.uns["memento"]["groups"]
+        n_donors = len(groups)
+
+        treatment = pd.DataFrame(
+            {
+                "snp_A": rng.integers(0, 3, size=n_donors).astype(float),
+                "snp_B": rng.integers(0, 3, size=n_donors).astype(float),
+                "snp_C": rng.integers(0, 3, size=n_donors).astype(float),
+                "snp_monomorphic": np.zeros(n_donors),
+            },
+            index=groups,
+        )
+        genes = list(adata.var.index[:6])
+        treatment_for_gene = {
+            genes[0]: ["snp_A", "snp_monomorphic"],
+            genes[1]: ["snp_B", "snp_C"],
+            genes[2]: ["snp_monomorphic"],  # fully dropped
+            genes[3]: ["snp_A", "snp_B", "snp_C", "snp_monomorphic"],
+            genes[4]: ["snp_C"],
+            genes[5]: ["snp_A", "snp_monomorphic", "snp_B"],
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            main.ht_1d_moments(
+                adata,
+                treatment=treatment,
+                treatment_for_gene=treatment_for_gene,
+                num_boot=200,
+                verbose=0,
+                num_cpus=1,
+                resample_rep=True,
+                random_state=42,
+            )
+        return main.get_1d_ht_result(adata).set_index(["gene", "tx"]).sort_index()
+
+    result1 = run()
+    result2 = run()
+
+    # Fully-dropped gene never appears; every other gene keeps exactly its
+    # surviving (non-constant) columns.
+    assert (result1.index.get_level_values("tx") == "snp_monomorphic").sum() == 0
+    assert result1.index.equals(result2.index)
+    pd.testing.assert_frame_equal(result1, result2)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -578,3 +578,56 @@ def test_ht_1d_moments_result_alignment_is_reproducible_with_mixed_dropouts():
     assert (result1.index.get_level_values("tx") == "snp_monomorphic").sum() == 0
     assert result1.index.equals(result2.index)
     pd.testing.assert_frame_equal(result1, result2)
+
+
+def test_ht_1d_moments_still_errors_on_nonexistent_gene_with_constant_only_column():
+    # Regression test: a gene that doesn't exist in adata.var should always
+    # raise a clear "gene not found" error, even if its only assigned
+    # treatment column happens to be constant (which would otherwise cause
+    # the zero-variance pre-filter to silently drop it first, masking the
+    # real problem -- a typo or a stale gene name -- behind a misleading
+    # "nothing to test" warning instead).
+    rng = np.random.default_rng(5)
+    adata = _build_donor_adata(rng)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    treatment = pd.DataFrame({"constant_col": np.zeros(n_donors)}, index=groups)
+    treatment_for_gene = {"totally_fake_gene": ["constant_col"]}
+
+    with pytest.raises(ValueError, match="Genes not found"):
+        main.ht_1d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=50,
+            verbose=0,
+            num_cpus=1,
+        )
+
+
+def test_ht_1d_moments_still_drops_real_gene_with_constant_only_column():
+    # Sanity check that the fix above doesn't overcorrect: a gene that
+    # genuinely exists, with only a constant column assigned, should still
+    # be silently dropped (no error), same as before.
+    rng = np.random.default_rng(6)
+    adata = _build_donor_adata(rng)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    treatment = pd.DataFrame({"constant_col": np.zeros(n_donors)}, index=groups)
+    real_gene = adata.var.index[0]
+    treatment_for_gene = {real_gene: ["constant_col"]}
+
+    with pytest.warns(UserWarning, match="Dropping"):
+        main.ht_1d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=50,
+            verbose=0,
+            num_cpus=1,
+        )
+
+    result = main.get_1d_ht_result(adata)
+    assert result.shape == (0, 8)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -631,3 +631,60 @@ def test_ht_1d_moments_still_drops_real_gene_with_constant_only_column():
 
     result = main.get_1d_ht_result(adata)
     assert result.shape == (0, 8)
+
+
+def test_ht_2d_moments_errors_on_nonexistent_gene_pair_with_constant_only_column():
+    # Regression test mirroring the 1D fix: a gene pair that was never
+    # computed via compute_2d_moments should always raise a clear error,
+    # even if its only assigned treatment column happens to be constant.
+    rng = np.random.default_rng(8)
+    adata = _build_donor_adata(rng, n_genes=20)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    surviving = adata.uns["memento"]["gene_list"]
+    g0, g1 = surviving[0], surviving[1]
+    main.compute_2d_moments(adata, [(g0, g1)])
+
+    treatment = pd.DataFrame({"constant_col": np.zeros(n_donors)}, index=groups)
+    treatment_for_gene = {("fake_gene_x", "fake_gene_y"): ["constant_col"]}
+
+    with pytest.raises(ValueError, match="Gene pairs not found"):
+        main.ht_2d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=50,
+            verbose=0,
+            num_cpus=1,
+        )
+
+
+def test_ht_2d_moments_still_drops_real_pair_with_constant_only_column():
+    # Sanity check that the fix above doesn't overcorrect: a real,
+    # previously-computed pair with only a constant column assigned should
+    # still be silently dropped (no error), same as before.
+    rng = np.random.default_rng(9)
+    adata = _build_donor_adata(rng, n_genes=20)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    surviving = adata.uns["memento"]["gene_list"]
+    g0, g1 = surviving[0], surviving[1]
+    main.compute_2d_moments(adata, [(g0, g1)])
+
+    treatment = pd.DataFrame({"constant_col": np.zeros(n_donors)}, index=groups)
+    treatment_for_gene = {(g0, g1): ["constant_col"]}
+
+    with pytest.warns(UserWarning, match="Dropping"):
+        main.ht_2d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=50,
+            verbose=0,
+            num_cpus=1,
+        )
+
+    result = main.get_2d_ht_result(adata)
+    assert result.shape == (0, 6)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+import warnings
 from scipy import sparse
 
 from memento import main
@@ -237,3 +238,219 @@ def test_compute_1d_moments_raises_informative_error_for_sparse_group():
 
     with pytest.raises(ValueError, match="sg\\^C"):
         main.compute_1d_moments(adata, min_perc_group=0.3)
+
+
+def _build_donor_adata(rng, n_genes=50, n_donors=20, cells_per_donor=10, lam=3.0):
+    """Shared fixture-style helper: a donor-structured AnnData with enough
+    genes for setup_memento's internal binning to behave sensibly."""
+    counts = rng.poisson(lam, size=(n_donors * cells_per_donor, n_genes))
+    obs = pd.DataFrame(
+        {
+            "capture_rate": np.full(n_donors * cells_per_donor, 0.1),
+            "donor": np.repeat([f"d{i}" for i in range(n_donors)], cells_per_donor),
+        },
+        index=[f"c{i}" for i in range(n_donors * cells_per_donor)],
+    )
+    var = pd.DataFrame(index=[f"gene_{i}" for i in range(n_genes)])
+    adata = ad.AnnData(X=sparse.csr_matrix(counts.astype(float)), obs=obs, var=var)
+    main.setup_memento(adata, q_column="capture_rate", filter_mean_thresh=0.0)
+    main.create_groups(adata, ["donor"])
+    main.compute_1d_moments(adata, min_perc_group=0.3)
+    return adata
+
+
+def test_drop_constant_treatment_columns_global_case():
+    # treatment_for_gene=None: constant columns apply to every gene, so the
+    # function should just report which columns of `treatment` are constant.
+    treatment = pd.DataFrame(
+        {
+            "varies": [0.0, 1.0, 0.0, 1.0],
+            "constant": [5.0, 5.0, 5.0, 5.0],
+        }
+    )
+
+    filtered_tfg, constant_cols = main._drop_constant_treatment_columns(treatment, None)
+
+    assert filtered_tfg is None
+    assert constant_cols == ["constant"]
+
+
+def test_drop_constant_treatment_columns_per_gene_case():
+    # treatment_for_gene provided: constant columns should be removed from
+    # each gene's own list; a gene whose only column is constant should be
+    # dropped entirely; a gene with no constant columns is untouched.
+    treatment = pd.DataFrame(
+        {
+            "snp_a": [0.0, 1.0, 2.0, 1.0],
+            "snp_b": [1.0, 1.0, 1.0, 1.0],  # constant
+        }
+    )
+    treatment_for_gene = {
+        "gene_1": ["snp_a", "snp_b"],  # mixed -> keep only snp_a
+        "gene_2": ["snp_b"],  # only constant -> dropped entirely
+        "gene_3": ["snp_a"],  # unaffected
+    }
+
+    filtered_tfg, dropped = main._drop_constant_treatment_columns(treatment, treatment_for_gene)
+
+    assert filtered_tfg == {"gene_1": ["snp_a"], "gene_3": ["snp_a"]}
+    assert set(dropped) == {("gene_1", "snp_b"), ("gene_2", "snp_b")}
+    assert "gene_2" not in filtered_tfg
+
+
+def test_prefilter_constant_treatment_warns_and_drops_global():
+    treatment = pd.DataFrame(
+        {
+            "varies": [0.0, 1.0, 0.0, 1.0],
+            "constant": [5.0, 5.0, 5.0, 5.0],
+        }
+    )
+
+    with pytest.warns(UserWarning, match="Dropping treatment column"):
+        filtered_treatment, treatment_for_gene = main._prefilter_constant_treatment(treatment, None)
+
+    assert list(filtered_treatment.columns) == ["varies"]
+    assert treatment_for_gene is None
+
+
+def test_prefilter_constant_treatment_warns_and_drops_per_gene():
+    treatment = pd.DataFrame(
+        {
+            "snp_a": [0.0, 1.0, 2.0, 1.0],
+            "snp_b": [1.0, 1.0, 1.0, 1.0],
+        }
+    )
+    treatment_for_gene = {"gene_1": ["snp_a", "snp_b"], "gene_2": ["snp_b"]}
+
+    with pytest.warns(UserWarning, match="Dropping 2 gene/treatment-column pair"):
+        _, filtered_tfg = main._prefilter_constant_treatment(treatment, treatment_for_gene)
+
+    assert filtered_tfg == {"gene_1": ["snp_a"]}
+
+
+def test_prefilter_constant_treatment_no_warning_when_nothing_constant():
+    treatment = pd.DataFrame({"snp_a": [0.0, 1.0, 2.0, 1.0]})
+    treatment_for_gene = {"gene_1": ["snp_a"]}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes a test failure
+        result_treatment, result_tfg = main._prefilter_constant_treatment(treatment, treatment_for_gene)
+
+    assert list(result_treatment.columns) == ["snp_a"]
+    assert result_tfg == treatment_for_gene
+
+
+def test_ht_1d_moments_drops_monomorphic_snp_per_gene():
+    # End-to-end regression test for issue #38: an eQTL-style scan with a
+    # monomorphic SNP mixed in with a normal one. Previously this produced
+    # divide-by-zero/degrees-of-freedom warnings and unreliable output for
+    # the monomorphic SNP; it should now be silently excluded from the
+    # results (with a single informative warning), leaving only the valid
+    # SNP's results.
+    rng = np.random.default_rng(0)
+    adata = _build_donor_adata(rng)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    treatment = pd.DataFrame(
+        {
+            "snp_normal": rng.integers(0, 3, size=n_donors).astype(float),
+            "snp_monomorphic": np.zeros(n_donors),
+        },
+        index=groups,
+    )
+    treatment_for_gene = {
+        gene: ["snp_normal", "snp_monomorphic"] for gene in adata.var.index[:3]
+    }
+
+    with pytest.warns(UserWarning, match="Dropping"):
+        main.ht_1d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=100,
+            verbose=0,
+            num_cpus=1,
+            resample_rep=True,
+        )
+
+    result = main.get_1d_ht_result(adata)
+
+    assert (result["tx"] == "snp_monomorphic").sum() == 0
+    assert set(result["tx"].unique()) == {"snp_normal"}
+    assert not result["de_coef"].isna().any()
+
+
+def test_ht_1d_moments_drops_constant_column_global_case():
+    rng = np.random.default_rng(1)
+    adata = _build_donor_adata(rng)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    treatment = pd.DataFrame(
+        {
+            "condition": rng.integers(0, 2, size=n_donors).astype(float),
+            "constant_col": np.full(n_donors, 5.0),
+        },
+        index=groups,
+    )
+
+    with pytest.warns(UserWarning, match="Dropping treatment column"):
+        main.ht_1d_moments(adata, treatment=treatment, num_boot=100, verbose=0, num_cpus=1)
+
+    result = main.get_1d_ht_result(adata)
+
+    assert set(result["tx"].unique()) == {"condition"}
+
+
+def test_ht_2d_moments_drops_pair_when_all_treatment_columns_constant():
+    # End-to-end regression test for issue #38 in the 2D/coexpression path:
+    # a gene pair whose only assigned treatment column is constant should
+    # be dropped entirely from the results, not just have its coefficient
+    # set to something invalid.
+    rng = np.random.default_rng(2)
+    adata = _build_donor_adata(rng, n_genes=30)
+    groups = adata.uns["memento"]["groups"]
+    n_donors = len(groups)
+
+    surviving_genes = adata.uns["memento"]["gene_list"]
+    g0, g1, g2, g3, g4, g5 = surviving_genes[:6]
+    gene_pairs = [(g0, g1), (g2, g3), (g4, g5)]
+    main.compute_2d_moments(adata, gene_pairs)
+
+    treatment = pd.DataFrame(
+        {
+            "snp_normal": rng.integers(0, 3, size=n_donors).astype(float),
+            "snp_monomorphic": np.zeros(n_donors),
+        },
+        index=groups,
+    )
+    treatment_for_gene = {
+        (g0, g1): ["snp_normal", "snp_monomorphic"],  # mixed -> keep snp_normal only
+        (g2, g3): ["snp_monomorphic"],  # only constant -> pair vanishes entirely
+        (g4, g5): ["snp_normal"],  # unaffected
+    }
+
+    with pytest.warns(UserWarning, match="Dropping"):
+        main.ht_2d_moments(
+            adata,
+            treatment=treatment,
+            treatment_for_gene=treatment_for_gene,
+            num_boot=100,
+            verbose=0,
+            num_cpus=1,
+            resample_rep=True,
+        )
+
+    result = main.get_2d_ht_result(adata)
+
+    pair_23_present = (
+        ((result["gene_1"] == g2) & (result["gene_2"] == g3))
+        | ((result["gene_1"] == g3) & (result["gene_2"] == g2))
+    ).any()
+    assert not pair_23_present
+
+    pair_01_mask = ((result["gene_1"] == g0) & (result["gene_2"] == g1)) | (
+        (result["gene_1"] == g1) & (result["gene_2"] == g0)
+    )
+    assert set(result.loc[pair_01_mask, "tx"]) == {"snp_normal"}


### PR DESCRIPTION
Fixes #38

Two related problems, addressed separately per their actual nature:

**1. Constant treatment columns are now pre-filtered, not run.** A treatment column with zero variance across the groups being tested (e.g. a monomorphic SNP genotype in an eQTL scan) has nothing to estimate. Previously it would run through the full bootstrap/regression machinery, hit a broken guard (`(treatment == 1).mean()==1`, which only caught the specific case of a column constant at exactly `1`, not any other value) and fall through to produce warnings and unreliable output.

`ht_1d_moments` and `ht_2d_moments` now drop constant treatment columns before any bootstrap computation runs. Affected genes/gene-pairs are silently excluded from results (with one summary warning), consistent with how genes that fail the expression filter are already excluded elsewhere. The broken `(treatment == 1)` shortcut is removed from `_regress_1d`/`_regress_2d` entirely -- it's unreachable now, and was actively inconsistent (a column constant at exactly 1 got real-looking but meaningless numbers, while any other constant value fell through to the broken path).

`ht_2d_moments` needed two more fixes surfaced while testing this: its `num_tests` computation and `get_2d_ht_result` both did an unguarded `treatment_for_gene[pair]` lookup that would `KeyError` once a pair's columns could be fully dropped. Both now use `.get(pair, [])`.

**2. Degenerate individual bootstrap iterations are now quiet, not just tolerated.** Separately: even a genuinely-varying treatment column can, purely by chance, have one bootstrap iteration resample a subset where it comes out constant (e.g. a small donor cohort drawing the same genotype repeatedly). This can't be caught by pre-filtering, since it's only knowable after resampling. The resulting NaN is already well-tolerated by the downstream `nanmean`/`nanstd` aggregation, but computing it via an actual division by zero triggers a `RuntimeWarning` every time -- exactly the volume of noise #38 describes over a large scan. `_cross_coef_resampled` now uses the same safe-division + explicit-NaN pattern already used in `_cross_coef` (from #64) to avoid the division rather than just suppress the resulting warning.

Verified directly that a genuinely constant treatment column's `LinearRegression` residual is *exactly* zero (not just near-zero) across 200 randomized realistic conditions, so an exact equality check is sufficient for the pre-filter.

**Tests:** unit tests for the pre-filter helper (global and per-gene/per-pair cases, warning behavior), end-to-end regression tests through the real `ht_1d_moments`/`ht_2d_moments` pipelines (including a gene pair losing all vs. only some of its treatment columns), and a unit test for `_cross_coef_resampled`'s new guard using `np.errstate` to confirm no warning fires. Full suite (41 tests) passes.