### PR TITLE
Replace np.in1d with np.isin for numpy 2 compatibility

### DIFF
--- a/memento/estimator.py
+++ b/memento/estimator.py
@@ -279,7 +279,7 @@ def _good_mean_only(data, n_obs, q, size_factor=None, alpha=0, max_to_replace=13
 
         corrected_counts = sparse.diags(1/size_factor) @ corrected_counts # normalize for size_factor
         nonzero_sum = corrected_counts.sum(axis=0).A1
-        zero_sum = np.array([(final_values[0, idx]/size_factor[~np.in1d(range(size_factor.shape[0]), sparse.find(arr[:, idx])[0])]).sum() for idx in range(n_genes)])
+        zero_sum = np.array([(final_values[0, idx]/size_factor[~np.isin(range(size_factor.shape[0]), sparse.find(arr[:, idx])[0])]).sum() for idx in range(n_genes)])
         m = (nonzero_sum + zero_sum)/arr.shape[0]
         
         return [m, np.ones(m.shape)*10]

--- a/memento/main.py
+++ b/memento/main.py
@@ -414,7 +414,7 @@ def compute_1d_moments(
     # If a gene list is given, use that to further filter the moments
     if gene_list is not None:
         assert isinstance(gene_list, list)
-        given_gene_mask = np.in1d(adata.var.index.values, gene_list)
+        given_gene_mask = np.isin(adata.var.index.values, gene_list)
 
         adata.uns['memento']['group_cells'] = \
             {group:adata.uns['memento']['group_cells'][group][:, given_gene_mask] for group in group_names}


### PR DESCRIPTION
Fixes #73.

`np.in1d` was removed in numpy 2.0, so `compute_1d_moments` raises `AttributeError` on any current environment — the package is unusable with `gene_list=` on numpy >= 2.

Two call sites, one line each:
- `memento/main.py:417` — a 1-D gene index
- `memento/estimator.py:282` — a `range`

`np.isin` is the drop-in replacement, recommended since numpy 1.13. It preserves the shape of its first argument where `np.in1d` always flattened, but neither call site depends on flattening, so the behaviour is identical here.

Verified on numpy 2.4.6: `compute_1d_moments` and `compute_2d_moments` run, and recomputing Figure 3's control gene-by-gene correlation matrix under the patched package reproduces the previously stored one bit for bit (max abs diff 0.0 over 617×617).

Split out of #72 at the maintainer's request. That branch carries the same one-line change so it can run standalone; whichever merges first, the other applies cleanly since the edits are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEVDHBizrVAsJ3MDaCxujb