### PR TITLE
Don't paste stale panels into assembled figures; preserve existing Zenodo metadata on merge

### DIFF
--- a/publication/figure5/make_figure5.py
+++ b/publication/figure5/make_figure5.py
@@ -36,6 +36,7 @@ def main():
                         help='rebuild the sheet from existing panel pngs; panel A is slow')
     args = parser.parse_args()
 
+    skipped = set()
     if not args.assemble_only:
         for module in [panel_a_qqplots, panel_b_roc, panel_c_power,
                        panel_de_atac, panel_fi_examples]:
@@ -49,9 +50,16 @@ def main():
                 if module is not panel_fi_examples:
                     raise
                 print(f'skipping panels F-I:\n{reason}', flush=True)
+                skipped.add('figure5FI')
 
+    # A panel that was skipped this run is excluded even if its png is still on disk from
+    # an earlier one. Assembling from whatever files exist would otherwise paste a stale
+    # panel into a fresh sheet -- and F-I is exactly the panel someone runs once with
+    # dbGaP access and then again without, so the sheet would silently claim to show
+    # something this run did not produce.
     panels = [entry for entry in SHEET
-              if os.path.exists(config.figure_path(f'{entry[0]}.png'))]
+              if entry[0] not in skipped
+              and os.path.exists(config.figure_path(f'{entry[0]}.png'))]
     missing = [label for stem, label in SHEET if (stem, label) not in panels]
     if missing:
         print(f'assembling without: {", ".join(missing)}')

--- a/publication/zenodo_metadata.py
+++ b/publication/zenodo_metadata.py
@@ -95,6 +95,13 @@ instructions, and what each figure should produce, are in
 '''
 
 
+# Fields this script owns. Everything else on an existing draft -- title, creators with
+# their ORCIDs and affiliations, publication_date, access_right -- is set by a human on
+# the website and is preserved by --merge-into. A bare PUT replaces metadata wholesale,
+# so overwriting rather than merging silently drops all of it.
+OWNED = ('upload_type', 'description', 'related_identifiers', 'keywords', 'version')
+
+
 def metadata():
     return {
         'metadata': {
@@ -117,9 +124,33 @@ def metadata():
     }
 
 
+def merged(existing):
+    """Existing metadata, with only this script's fields added or replaced."""
+    out = dict(existing)
+    generated = metadata()['metadata']
+    for field in OWNED:
+        if field in generated:
+            out[field] = generated[field]
+    return {'metadata': out}
+
+
 def main():
-    argparse.ArgumentParser(description=__doc__).parse_args()
-    json.dump(metadata(), sys.stdout, indent=2)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--merge-into', metavar='FILE',
+                        help='a deposition JSON fetched from Zenodo. Its metadata is kept '
+                             'and only this script\'s fields are added, so a title, '
+                             'ORCIDs and affiliations set on the website survive.')
+    args = parser.parse_args()
+
+    if args.merge_into:
+        with open(args.merge_into) as handle:
+            existing = json.load(handle).get('metadata', {})
+        existing.pop('prereserve_doi', None)   # read-only; Zenodo rejects it on PUT
+        existing.pop('doi', None)
+        payload = merged(existing)
+    else:
+        payload = metadata()
+    json.dump(payload, sys.stdout, indent=2)
     sys.stdout.write('\n')
 
 


### PR DESCRIPTION
Two small fixes found during the final visual check of the regenerated figures, after #78 merged.

## A skipped panel could still appear in the sheet

`make_figure5.py` assembles from whichever panel pngs are on disk. A run that skipped panels F–I — because the controlled-access genotypes are not in the public bundle — still pasted in an `figure5FI.png` left over from an earlier run that *did* have them. The run printed `skipping panels F-I` and then wrote a sheet showing F–I, 16 hours stale and from a different data source.

That is precisely the panel where it matters: run figure 5 once with dbGaP access, then again from the public bundle, and the second sheet silently claims to show something that run did not produce. On a clean checkout the behaviour was correct, which is why it survived the earlier validation.

A panel skipped this run is now excluded regardless of what is on disk. Verified:

```
skipping panels F-I: ...
assembling without: F / G / H / I
wrote figure5.png
```

The same hazard exists in principle for every `make_figureN.py` — they all assemble from disk. Figure 5 is the only one that skips a panel by design, so it is the only one where a skip and a stale file can disagree.

## `zenodo_metadata.py` would have clobbered the record's metadata

A `PUT` to a Zenodo deposition replaces metadata wholesale. The generated payload carried `creators: [{'name': 'Kim, Min Cheol'}]`, so applying it to the real record would have dropped the **ORCID and affiliation** set on the website, along with the title, publication date and access setting.

`--merge-into FILE` takes a deposition fetched from Zenodo, keeps its metadata, and replaces only the fields this script owns (`upload_type`, `description`, `related_identifiers`, `keywords`, `version`). That is how the live record was actually populated — the title and ORCID survived because of it.